### PR TITLE
#203 - Nuanced types

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,0 +1,13 @@
+use specta::{datatype::TypeImpl, Type};
+
+#[derive(Type)]
+pub struct Demo {
+    a: String,
+}
+
+fn main() {
+    // let a = TypeImpl::new::<String>();
+    // let b = TypeImpl::new::<i32>();
+    // let c = TypeImpl::new::<Demo>();
+    // println!("{a:?}\n{b:?}\n{c:?}");
+}

--- a/src/datatype/list.rs
+++ b/src/datatype/list.rs
@@ -6,6 +6,8 @@ pub struct List {
     pub(crate) ty: Box<DataType>,
     // Length is set for `[Type; N]` arrays.
     pub(crate) length: Option<usize>,
+    // Are each elements unique? Eg. `HashSet` or `BTreeSet`
+    pub(crate) unique: bool,
 }
 
 impl List {
@@ -15,5 +17,9 @@ impl List {
 
     pub fn length(&self) -> Option<usize> {
         self.length
+    }
+
+    pub fn unique(&self) -> bool {
+        self.unique
     }
 }

--- a/src/datatype/literal.rs
+++ b/src/datatype/literal.rs
@@ -22,6 +22,7 @@ pub enum LiteralType {
     String(String),
     char(char),
     /// Standalone `null` without a known type
+    // TODO: Remove this
     None,
 }
 

--- a/src/datatype/map.rs
+++ b/src/datatype/map.rs
@@ -1,0 +1,37 @@
+use crate::DataType;
+
+#[derive(Debug, Clone, PartialEq)]
+
+pub struct Map {
+    // TODO: Box these fields together as an internal optimization.
+    // The type of the map keys.
+    pub(crate) key_ty: Box<DataType>,
+    // The type of the map values.
+    pub(crate) value_ty: Box<DataType>,
+    // Are each elements unique? Eg. `HashSet` or `BTreeSet`
+    pub(crate) unique: bool,
+}
+
+impl Map {
+    // TODO: `inline` vs `reference` is a thing people downstream need to think about.
+    // TODO: Should this need `generics`
+    // pub fn new<K: Type, V: Type>(type_map: &mut TypeMap, generics: &[DataType]) -> Self {
+    //     Self {
+    //         key_ty: Box::new(K::inline(type_map, generics)),
+    //         value_ty: Box::new(V::inline(type_map, generics)),
+    //         unique: false,
+    //     }
+    // }
+
+    pub fn key_ty(&self) -> &DataType {
+        &self.key_ty
+    }
+
+    pub fn value_ty(&self) -> &DataType {
+        &self.value_ty
+    }
+
+    pub fn unique(&self) -> bool {
+        self.unique
+    }
+}

--- a/src/datatype/mod.rs
+++ b/src/datatype/mod.rs
@@ -13,6 +13,7 @@ mod primitive;
 pub mod reference;
 mod r#struct;
 mod tuple;
+mod r#type;
 
 pub use fields::*;
 pub use list::*;
@@ -22,6 +23,7 @@ pub use named::*;
 pub use primitive::*;
 pub use r#enum::*;
 pub use r#struct::*;
+pub use r#type::*;
 pub use tuple::*;
 
 use crate::SpectaID;

--- a/src/datatype/mod.rs
+++ b/src/datatype/mod.rs
@@ -7,6 +7,7 @@ mod r#enum;
 mod fields;
 mod list;
 mod literal;
+mod map;
 mod named;
 mod primitive;
 pub mod reference;
@@ -16,6 +17,7 @@ mod tuple;
 pub use fields::*;
 pub use list::*;
 pub use literal::*;
+pub use map::*;
 pub use named::*;
 pub use primitive::*;
 pub use r#enum::*;
@@ -33,7 +35,7 @@ pub enum DataType {
     Primitive(PrimitiveType),
     Literal(LiteralType),
     List(List),
-    Map(Box<(DataType, DataType)>),
+    Map(Map),
     Enum(EnumType),
     Tuple(TupleType),
     Reference(DataTypeReference),

--- a/src/datatype/mod.rs
+++ b/src/datatype/mod.rs
@@ -29,24 +29,24 @@ use crate::SpectaID;
 /// A language exporter takes this general format and converts it into a language specific syntax.
 #[derive(Debug, Clone, PartialEq)]
 pub enum DataType {
-    // Always inlined
-    Any,
-    Unknown,
+    Nullable(Box<DataType>),
     Primitive(PrimitiveType),
     Literal(LiteralType),
-    /// Either a `Set` or a `Vec`
     List(List),
-    Nullable(Box<DataType>),
     Map(Box<(DataType, DataType)>),
-    // Anonymous Reference types
-    Struct(StructType),
     Enum(EnumType),
     Tuple(TupleType),
-    // Result
-    Result(Box<(DataType, DataType)>),
-    // A reference type that has already been defined
     Reference(DataTypeReference),
     Generic(GenericType),
+
+    // TODO: Should we keep this - https://github.com/oscartbeaumont/specta/issues/192
+    Result(Box<(DataType, DataType)>),
+
+    // TODO: Remove these
+    Any,
+    Unknown,
+    Struct(StructType),
+    // Named(NamedDataType)
 }
 
 impl DataType {

--- a/src/datatype/mod.rs
+++ b/src/datatype/mod.rs
@@ -31,7 +31,6 @@ use crate::SpectaID;
 /// A language exporter takes this general format and converts it into a language specific syntax.
 #[derive(Debug, Clone, PartialEq)]
 pub enum DataType {
-    Nullable(Box<DataType>),
     Primitive(PrimitiveType),
     Literal(LiteralType),
     List(List),
@@ -41,6 +40,9 @@ pub enum DataType {
     Reference(DataTypeReference),
     Generic(GenericType),
 
+    // TODO: Can we avoid these being nestable
+    Nullable(Box<DataType>),
+
     // TODO: Should we keep this - https://github.com/oscartbeaumont/specta/issues/192
     Result(Box<(DataType, DataType)>),
 
@@ -48,13 +50,14 @@ pub enum DataType {
     Any,
     Unknown,
     Struct(StructType),
+    // TODO: Introduce this
     // Named(NamedDataType)
 }
 
 impl DataType {
     pub fn generics(&self) -> Option<&Vec<GenericType>> {
         match self {
-            Self::Struct(s) => Some(s.generics()),
+            // Self::Struct(s) => Some(s.generics()),
             Self::Enum(e) => Some(e.generics()),
             _ => None,
         }

--- a/src/datatype/named.rs
+++ b/src/datatype/named.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use crate::{DataType, DeprecatedType, ImplLocation, SpectaID};
+use crate::{DataType, DeprecatedType, EnumType, ImplLocation, SpectaID, StructType};
 
 /// A NamedDataTypeImpl includes extra information which is only available for [NamedDataType]'s that come from a real Rust type.
 #[derive(Debug, Clone, PartialEq)]
@@ -37,6 +37,13 @@ pub struct NamedDataType {
     // This field is public because we match on it in flattening code. // TODO: Review if this can be made private when reviewing the flattening logic/error handling
     pub inner: DataType,
 }
+
+// // TODO: Rename this
+// #[derive(Debug, Clone, PartialEq)]
+// pub enum NamedDataTypeTODO {
+//     Struct(StructType),
+//     Enum(EnumType), // TODO
+// }
 
 impl NamedDataType {
     pub fn name(&self) -> &Cow<'static, str> {

--- a/src/datatype/reference.rs
+++ b/src/datatype/reference.rs
@@ -12,7 +12,7 @@ pub struct Reference {
 
 pub fn inline<T: Type + ?Sized>(type_map: &mut TypeMap, generics: &[DataType]) -> Reference {
     Reference {
-        inner: T::inline(type_map, generics),
+        inner: T::inline(type_map, generics).ty,
     }
 }
 

--- a/src/datatype/type.rs
+++ b/src/datatype/type.rs
@@ -1,0 +1,41 @@
+use std::{any::TypeId, panic::Location};
+
+use crate::{internal::type_id::non_static_type_id, DataType, Type};
+
+#[derive(Debug)]
+pub struct TypeImpl {
+    name: &'static str,
+    tid: TypeId,
+    file: &'static str,
+    line: u32,
+    column: u32,
+    // TODO: Not `pub`
+    pub ty: DataType,
+}
+
+// TODO: Debug impl + ordering
+
+impl TypeImpl {
+    // TODO: Do we make this private for the macro only??? Probs
+    // TODO: Anyone could call this on any type but the `caller` information will be inconsistent.
+    #[track_caller]
+    pub fn new<T: Type>(ty: DataType) -> Self {
+        let caller = Location::caller();
+        Self {
+            name: std::any::type_name::<T>(),
+            tid: non_static_type_id::<T>(),
+            file: caller.file(),
+            line: caller.line(),
+            column: caller.column(),
+            ty,
+        }
+    }
+
+    // TODO: Field accessors
+
+    // TODO: Iterator for module path derived from `name` field
+
+    pub fn is<T: Type>() -> bool {
+        todo!();
+    }
+}

--- a/src/lang/ts/mod.rs
+++ b/src/lang/ts/mod.rs
@@ -59,7 +59,7 @@ pub fn inline_ref<T: Type>(_: &T, conf: &ExportConfig) -> Output {
 /// Eg. `{ demo: string; };`
 pub fn inline<T: Type>(conf: &ExportConfig) -> Output {
     let mut type_map = TypeMap::default();
-    let ty = T::inline(&mut type_map, &[]);
+    let ty = T::inline(&mut type_map, &[]).ty;
     is_valid_ty(&ty, &type_map)?;
     let result = datatype(conf, &ty, &type_map);
 

--- a/src/lang/ts/mod.rs
+++ b/src/lang/ts/mod.rs
@@ -255,8 +255,8 @@ pub(crate) fn datatype_inner(ctx: ExportContext, typ: &DataType, type_map: &Type
             format!(
                 // We use this isn't of `Record<K, V>` to avoid issues with circular references.
                 "{{ [key in {}]: {} }}",
-                datatype_inner(ctx.clone(), &def.0, type_map)?,
-                datatype_inner(ctx, &def.1, type_map)?
+                datatype_inner(ctx.clone(), def.key_ty(), type_map)?,
+                datatype_inner(ctx, def.value_ty(), type_map)?
             )
         }
         // We use `T[]` instead of `Array<T>` to avoid issues with circular references.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc = include_str!("./docs.md")]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![warn(clippy::all, clippy::unwrap_used, clippy::panic)] // TODO: missing_docs
 #![allow(clippy::module_inception)]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/src/static_types.rs
+++ b/src/static_types.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use crate::{DataType, Type, TypeMap};
+use crate::{DataType, Type, TypeImpl, TypeMap};
 
 /// Easily convert a non-Specta type into a Specta compatible type.
 /// This will be typed as `any` in Typescript.
@@ -34,8 +34,8 @@ use crate::{DataType, Type, TypeMap};
 pub struct Any<T = ()>(T);
 
 impl<T> Type for Any<T> {
-    fn inline(_: &mut TypeMap, _: &[DataType]) -> DataType {
-        DataType::Any
+    fn inline(_: &mut TypeMap, _: &[DataType]) -> TypeImpl {
+        TypeImpl::new::<Self>(DataType::Any)
     }
 }
 
@@ -97,8 +97,8 @@ impl<T: serde::Serialize> serde::Serialize for Any<T> {
 pub struct Unknown<T = ()>(T);
 
 impl<T> Type for Unknown<T> {
-    fn inline(_: &mut TypeMap, _: &[DataType]) -> DataType {
-        DataType::Unknown
+    fn inline(_: &mut TypeMap, _: &[DataType]) -> TypeImpl {
+        TypeImpl::new::<Self>(DataType::Unknown)
     }
 }
 

--- a/src/type/impls.rs
+++ b/src/type/impls.rs
@@ -192,42 +192,16 @@ impl<T> Type for std::marker::PhantomData<T> {
 #[allow(unused)]
 #[derive(Type)]
 #[specta(remote = std::convert::Infallible, crate = crate, export = false)]
-pub enum Infallible {}
+enum Infallible {}
 
-impl<T: Type> Type for std::ops::Range<T> {
-    fn inline(type_map: &mut TypeMap, _generics: &[DataType]) -> DataType {
-        let ty = Some(T::definition(type_map));
-        DataType::Struct(StructType {
-            name: "Range".into(),
-            sid: None,
-            generics: vec![],
-            fields: StructFields::Named(NamedFields {
-                fields: vec![
-                    (
-                        "start".into(),
-                        Field {
-                            optional: false,
-                            flatten: false,
-                            deprecated: None,
-                            docs: Cow::Borrowed(""),
-                            ty: ty.clone(),
-                        },
-                    ),
-                    (
-                        "end".into(),
-                        Field {
-                            optional: false,
-                            flatten: false,
-                            deprecated: None,
-                            docs: Cow::Borrowed(""),
-                            ty,
-                        },
-                    ),
-                ],
-                tag: None,
-            }),
-        })
-    }
+#[allow(unused)]
+#[derive(Type)]
+#[specta(remote = std::ops::Range, crate = crate, export = false)]
+struct Range<T> {
+    // TODO: Why is this introducing `'static` bound???
+    // TODO: Flatten these fields???
+    start: T,
+    end: T,
 }
 
 impl<T: Type> Type for std::ops::RangeInclusive<T> {
@@ -280,69 +254,13 @@ const _: () = {
         Object(Map<String, Value>),
     }
 
-    impl Type for Number {
-        fn inline(_: &mut TypeMap, _: &[DataType]) -> DataType {
-            DataType::Enum(EnumType {
-                name: "Number".into(),
-                sid: None,
-                repr: EnumRepr::Untagged,
-                skip_bigint_checks: true,
-                variants: vec![
-                    (
-                        "f64".into(),
-                        EnumVariant {
-                            skip: false,
-                            docs: Cow::Borrowed(""),
-                            deprecated: None,
-                            inner: EnumVariants::Unnamed(UnnamedFields {
-                                fields: vec![Field {
-                                    optional: false,
-                                    flatten: false,
-                                    deprecated: None,
-                                    docs: Cow::Borrowed(""),
-                                    ty: Some(DataType::Primitive(PrimitiveType::f64)),
-                                }],
-                            }),
-                        },
-                    ),
-                    (
-                        "i64".into(),
-                        EnumVariant {
-                            skip: false,
-                            docs: Cow::Borrowed(""),
-                            deprecated: None,
-                            inner: EnumVariants::Unnamed(UnnamedFields {
-                                fields: vec![Field {
-                                    optional: false,
-                                    flatten: false,
-                                    deprecated: None,
-                                    docs: Cow::Borrowed(""),
-                                    ty: Some(DataType::Primitive(PrimitiveType::i64)),
-                                }],
-                            }),
-                        },
-                    ),
-                    (
-                        "u64".into(),
-                        EnumVariant {
-                            skip: false,
-                            docs: Cow::Borrowed(""),
-                            deprecated: None,
-                            inner: EnumVariants::Unnamed(UnnamedFields {
-                                fields: vec![Field {
-                                    optional: false,
-                                    flatten: false,
-                                    deprecated: None,
-                                    docs: Cow::Borrowed(""),
-                                    ty: Some(DataType::Primitive(PrimitiveType::u64)),
-                                }],
-                            }),
-                        },
-                    ),
-                ],
-                generics: vec![],
-            })
-        }
+    #[allow(non_camel_case_types)]
+    #[derive(Type)]
+    #[specta(remote = Number, crate = crate, export = false)]
+    enum NumberDef {
+        f64(f64),
+        i64(i64),
+        u64(u64),
     }
 };
 
@@ -379,69 +297,13 @@ const _: () = {
         }
     }
 
-    impl Type for serde_yaml::Number {
-        fn inline(_: &mut TypeMap, _: &[DataType]) -> DataType {
-            DataType::Enum(EnumType {
-                name: "Number".into(),
-                sid: None,
-                repr: EnumRepr::Untagged,
-                skip_bigint_checks: true,
-                variants: vec![
-                    (
-                        "f64".into(),
-                        EnumVariant {
-                            skip: false,
-                            docs: Cow::Borrowed(""),
-                            deprecated: None,
-                            inner: EnumVariants::Unnamed(UnnamedFields {
-                                fields: vec![Field {
-                                    optional: false,
-                                    flatten: false,
-                                    deprecated: None,
-                                    docs: Cow::Borrowed(""),
-                                    ty: Some(DataType::Primitive(PrimitiveType::f64)),
-                                }],
-                            }),
-                        },
-                    ),
-                    (
-                        "i64".into(),
-                        EnumVariant {
-                            skip: false,
-                            docs: Cow::Borrowed(""),
-                            deprecated: None,
-                            inner: EnumVariants::Unnamed(UnnamedFields {
-                                fields: vec![Field {
-                                    optional: false,
-                                    flatten: false,
-                                    deprecated: None,
-                                    docs: Cow::Borrowed(""),
-                                    ty: Some(DataType::Primitive(PrimitiveType::i64)),
-                                }],
-                            }),
-                        },
-                    ),
-                    (
-                        "u64".into(),
-                        EnumVariant {
-                            skip: false,
-                            docs: Cow::Borrowed(""),
-                            deprecated: None,
-                            inner: EnumVariants::Unnamed(UnnamedFields {
-                                fields: vec![Field {
-                                    optional: false,
-                                    flatten: false,
-                                    deprecated: None,
-                                    docs: Cow::Borrowed(""),
-                                    ty: Some(DataType::Primitive(PrimitiveType::u64)),
-                                }],
-                            }),
-                        },
-                    ),
-                ],
-                generics: vec![],
-            })
-        }
+    #[allow(non_camel_case_types)]
+    #[derive(Type)]
+    #[specta(remote = serde_yaml::Number, crate = crate, export = false)]
+    enum NumberDef {
+        f64(f64),
+        i64(i64),
+        u64(u64),
     }
 };
 
@@ -649,100 +511,11 @@ const _: () = {
 impl_as!(url::Url as String);
 
 #[cfg(feature = "either")]
-impl<L: Type, R: Type> Type for either::Either<L, R> {
-    fn inline(type_map: &mut TypeMap, generics: &[DataType]) -> DataType {
-        DataType::Enum(EnumType {
-            name: "Either".into(),
-            sid: None,
-            repr: EnumRepr::Untagged,
-            skip_bigint_checks: false,
-            variants: vec![
-                (
-                    "Left".into(),
-                    EnumVariant {
-                        skip: false,
-                        docs: Cow::Borrowed(""),
-                        deprecated: None,
-                        inner: EnumVariants::Unnamed(UnnamedFields {
-                            fields: vec![Field {
-                                optional: false,
-                                flatten: false,
-                                deprecated: None,
-                                docs: Cow::Borrowed(""),
-                                ty: Some(L::inline(type_map, generics)),
-                            }],
-                        }),
-                    },
-                ),
-                (
-                    "Right".into(),
-                    EnumVariant {
-                        skip: false,
-                        docs: Cow::Borrowed(""),
-                        deprecated: None,
-                        inner: EnumVariants::Unnamed(UnnamedFields {
-                            fields: vec![Field {
-                                optional: false,
-                                flatten: false,
-                                deprecated: None,
-                                docs: Cow::Borrowed(""),
-                                ty: Some(R::inline(type_map, generics)),
-                            }],
-                        }),
-                    },
-                ),
-            ],
-            generics: vec![],
-        })
-    }
-
-    fn reference(type_map: &mut TypeMap, generics: &[DataType]) -> Reference {
-        Reference {
-            inner: DataType::Enum(EnumType {
-                name: "Either".into(),
-                sid: None,
-                repr: EnumRepr::Untagged,
-                skip_bigint_checks: false,
-                variants: vec![
-                    (
-                        "Left".into(),
-                        EnumVariant {
-                            skip: false,
-                            docs: Cow::Borrowed(""),
-                            deprecated: None,
-                            inner: EnumVariants::Unnamed(UnnamedFields {
-                                fields: vec![Field {
-                                    optional: false,
-                                    flatten: false,
-                                    deprecated: None,
-                                    docs: Cow::Borrowed(""),
-                                    ty: Some(L::reference(type_map, generics).inner),
-                                }],
-                            }),
-                        },
-                    ),
-                    (
-                        "Right".into(),
-                        EnumVariant {
-                            skip: false,
-                            docs: Cow::Borrowed(""),
-                            deprecated: None,
-                            inner: EnumVariants::Unnamed(UnnamedFields {
-                                fields: vec![Field {
-                                    optional: false,
-                                    flatten: false,
-                                    deprecated: None,
-                                    docs: Cow::Borrowed(""),
-                                    ty: Some(R::reference(type_map, generics).inner),
-                                }],
-                            }),
-                        },
-                    ),
-                ],
-                generics: vec![],
-            }),
-        }
-    }
+#[derive(Type)]
+#[specta(untagged, remote = either::Either, crate = crate, export = false)]
+enum Either<L: Type, R: Type> {
+    Left(L),
+    Right(R),
 }
 
 #[cfg(feature = "bevy_ecs")]

--- a/src/type/impls.rs
+++ b/src/type/impls.rs
@@ -121,6 +121,7 @@ impl<const N: usize, T: Type> Type for [T; N] {
                 },
             ),
             length: Some(N),
+            unique: false, // TODO: Properly hook this up
         })
     }
 
@@ -135,6 +136,7 @@ impl<const N: usize, T: Type> Type for [T; N] {
                     },
                 ),
                 length: Some(N),
+                unique: false, // TODO: Properly hook this up
             }),
         }
     }
@@ -369,10 +371,11 @@ const _: () = {
 
     impl Type for serde_yaml::value::TaggedValue {
         fn inline(_: &mut TypeMap, _: &[DataType]) -> DataType {
-            DataType::Map(Box::new((
-                DataType::Primitive(PrimitiveType::String),
-                DataType::Unknown,
-            )))
+            DataType::Map(crate::datatype::Map {
+                key_ty: Box::new(DataType::Primitive(PrimitiveType::String)),
+                value_ty: Box::new(DataType::Unknown),
+                unique: false, // TODO: Properly hook this up
+            })
         }
     }
 

--- a/src/type/macros.rs
+++ b/src/type/macros.rs
@@ -108,6 +108,7 @@ macro_rules! impl_for_list {
                         generics,
                     ))),
                     length: None,
+                    unique: false, // TODO: Properly hook this up
                 })
             }
 
@@ -118,6 +119,7 @@ macro_rules! impl_for_list {
                             || T::reference(type_map, generics).inner,
                         )),
                         length: None,
+                        unique: false, // TODO: Properly hook this up
                     }),
                 }
             }
@@ -129,30 +131,42 @@ macro_rules! impl_for_map {
     ($ty:path as $name:expr) => {
         impl<K: Type, V: Type> Type for $ty {
             fn inline(type_map: &mut TypeMap, generics: &[DataType]) -> DataType {
-                DataType::Map(Box::new((
-                    generics
-                        .get(0)
-                        .cloned()
-                        .unwrap_or_else(|| K::inline(type_map, generics)),
-                    generics
-                        .get(1)
-                        .cloned()
-                        .unwrap_or_else(|| V::inline(type_map, generics)),
-                )))
+                // TODO: This is a private-only API. We need a public alternative that somehow deals with `inline` vs `reference`.
+                DataType::Map(crate::datatype::Map {
+                    key_ty: Box::new(
+                        generics
+                            .get(0)
+                            .cloned()
+                            .unwrap_or_else(|| K::inline(type_map, generics)),
+                    ),
+                    value_ty: Box::new(
+                        generics
+                            .get(1)
+                            .cloned()
+                            .unwrap_or_else(|| V::inline(type_map, generics)),
+                    ),
+                    unique: false, // TODO: Properly hook this up
+                })
             }
 
             fn reference(type_map: &mut TypeMap, generics: &[DataType]) -> Reference {
                 Reference {
-                    inner: DataType::Map(Box::new((
-                        generics
-                            .get(0)
-                            .cloned()
-                            .unwrap_or_else(|| K::reference(type_map, generics).inner),
-                        generics
-                            .get(1)
-                            .cloned()
-                            .unwrap_or_else(|| V::reference(type_map, generics).inner),
-                    ))),
+                    // TODO: This is a private-only API. We need a public alternative that somehow deals with `inline` vs `reference`.
+                    inner: DataType::Map(crate::datatype::Map {
+                        key_ty: Box::new(
+                            generics
+                                .get(0)
+                                .cloned()
+                                .unwrap_or_else(|| K::reference(type_map, generics).inner),
+                        ),
+                        value_ty: Box::new(
+                            generics
+                                .get(1)
+                                .cloned()
+                                .unwrap_or_else(|| V::reference(type_map, generics).inner),
+                        ),
+                        unique: false, // TODO: Properly hook this up
+                    }),
                 }
             }
         }

--- a/src/type/macros.rs
+++ b/src/type/macros.rs
@@ -1,11 +1,13 @@
 macro_rules! impl_passthrough {
     ($t:ty) => {
         fn inline(type_map: &mut TypeMap, generics: &[DataType]) -> DataType {
-            <$t>::inline(type_map, generics)
+            // <$t>::inline(type_map, generics)
+            todo!();
         }
 
         fn reference(type_map: &mut TypeMap, generics: &[DataType]) -> Reference {
-            <$t>::reference(type_map, generics)
+            // <$t>::reference(type_map, generics)
+            todo!();
         }
     };
 }

--- a/src/type/mod.rs
+++ b/src/type/mod.rs
@@ -9,7 +9,7 @@ pub use map::*;
 pub use post_process::*;
 pub use specta_id::*;
 
-use crate::{reference, DataType, NamedDataType};
+use crate::{reference, DataType, NamedDataType, TypeImpl};
 
 use self::reference::Reference;
 
@@ -21,16 +21,19 @@ pub trait Type {
     /// [`definition`](crate::Type::definition) and [`reference`](crate::Type::definition)
     ///
     /// Implemented internally or via the [`Type`](derive@crate::Type) macro
-    fn inline(type_map: &mut TypeMap, generics: &[DataType]) -> DataType;
+    fn inline(type_map: &mut TypeMap, generics: &[DataType]) -> TypeImpl;
 
+    // TODO: Remove this in favor of it being an implementation detail of `inline`/`reference`???
     /// Small wrapper around [`inline`](crate::Type::inline) that provides
     /// [`definition_generics`](crate::Type::definition_generics)
     /// as the value for the `generics` arg.
     ///
     /// If your type is generic you *must* override the default implementation!
+    // TODO: TypeImpl
     fn definition(type_map: &mut TypeMap) -> DataType {
         // TODO: Remove this default impl?
-        Self::inline(type_map, &[])
+        // Self::inline(type_map, &[])
+        todo!();
     }
 
     /// Generates a datatype corresponding to a reference to this type,
@@ -42,6 +45,7 @@ pub trait Type {
     }
 }
 
+// TODO: This probs needs to go now because it's not relevant.
 /// NamedType represents a type that can be converted into [NamedDataType].
 /// This will be implemented for all types with the [Type] derive macro.
 pub trait NamedType: Type {

--- a/src/type/specta_id.rs
+++ b/src/type/specta_id.rs
@@ -49,6 +49,11 @@ impl PartialEq<Self> for SpectaID {
 pub struct ImplLocation(pub(crate) &'static str);
 
 impl ImplLocation {
+    #[track_caller]
+    pub fn new() -> Self {
+        Self(concat!(file!(), ":", line!(), ":", column!()))
+    }
+
     /// Get the location as a string
     pub const fn as_str(&self) -> &'static str {
         self.0

--- a/tests/macro/compile_error.stderr
+++ b/tests/macro/compile_error.stderr
@@ -52,11 +52,25 @@ error: specta: invalid formatted attribute
 103 | #[specta = "todo"]
     |   ^^^^^^
 
-error[E0601]: `main` function not found in crate `$CRATE`
-   --> tests/macro/compile_error.rs:104:36
+error: cannot find attribute `specta` in this scope
+   --> tests/macro/compile_error.rs:107:3
     |
-104 | pub struct InvalidSpectaAttribute2;
-    |                                    ^ consider adding a `main` function to `$DIR/tests/macro/compile_error.rs`
+107 | #[specta]
+    |   ^^^^^^
+    |
+    = note: `specta` is in scope, but it is a crate, not an attribute
+help: consider importing one of these items
+    |
+3   + use specta::specta;
+    |
+3   + use specta_macros::specta;
+    |
+
+error[E0601]: `main` function not found in crate `$CRATE`
+   --> tests/macro/compile_error.rs:108:20
+    |
+108 | pub fn testing() {}
+    |                    ^ consider adding a `main` function to `$DIR/tests/macro/compile_error.rs`
 
 error[E0277]: the trait bound `UnitExternal: specta::Flatten` is not satisfied
   --> tests/macro/compile_error.rs:32:11


### PR DESCRIPTION
The high-level thinking is to separate the idea of a Rust declaration and a Typescript type. Would this mean we can remove `Any`, `Unknown` and `PrimitiveType/LiteralType::None`.

Questions:
 - How should `List` and `Map` constructors deal with `inline` vs `reference`
 - Right now you can have a `DataType::Nullable(DataType::Nullable(...))` which is not great. Should we have it be more split up.
 - How does `DataTypeFrom` fit into this?
 - Should `Type::inline` go and instead have `Reference { inline: true }` and post-process it?
 - Should we merge `Reference` and `DatTypeReference`?? I feel like it makes it more typesafe so probs.
 - What if `inline` and `definition` become one method and the `generics` arg is an enum instead.
 - Removing `NamedType`???

TODO:
 - [ ] Can `ImplLocation` be constructed using `use_caller`? Should it be removed?
 - [ ] Public `List` constructor
 - [ ] Public `Map` constructor
 - [ ] `DataType::is`
 - [ ] Give each type a `SpectaID` including primitives.
 - [ ] `std::convert::Infallible` should be rejected by the Serde validator.
 - [ ] Rename `List` and `Map` to `ListType` and `MapType`
 - [ ] Support `!` but with Serde exporter warning
 - [ ] Option for static arrays. A normal data structure should require zero memory allocations. 


 Tied to #203 and #140.