### PR TITLE
Better `TypeId`

### DIFF
--- a/macros/src/type/mod.rs
+++ b/macros/src/type/mod.rs
@@ -44,7 +44,7 @@ pub fn derive(input: proc_macro::TokenStream) -> syn::Result<proc_macro::TokenSt
         unraw_raw_ident(&format_ident!("{}", raw_ident.to_string())).to_token_stream()
     });
 
-    let sid = quote!(#crate_ref::internal::construct::sid(#name, concat!("::", module_path!(), ":", line!(), ":", column!())));
+    let sid = quote!(#crate_ref::SpectaID::from::<Self>());
     let (inlines, reference, can_flatten) = match data {
         Data::Struct(data) => {
             parse_struct(&name, &container_attrs, generics, &crate_ref, &sid, data)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc = include_str!("./docs.md")]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![warn(clippy::all, clippy::unwrap_used, clippy::panic)] // TODO: missing_docs
 #![allow(clippy::module_inception)]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/src/type/specta_id.rs
+++ b/src/type/specta_id.rs
@@ -21,13 +21,23 @@ pub struct SpectaID {
 }
 
 impl SpectaID {
-    // TODO: Unit test this well including with non-static types.
+    // TODO: Unit test this (including with non-static types)
     pub fn from<T>() -> Self {
-        let type_name = std::any::type_name::<T>();
-        let last_segment = type_name.rfind("::").unwrap_or(type_name.len());
+        // I am aware `std::any::type_name`'s format is not guaranteed but plz just let me order my types by name without a macro in peace.
+        let type_name = std::any::type_name::<T>(); // Current output is in the form `some::Type<some::Generic>`
+
+        // Strip from `<` to the end of the string
+        let end_offset = type_name.rfind("<").unwrap_or(type_name.len());
+
+        // Strip everything before the last `::`
+        let start_offset = type_name[0..end_offset]
+            .rfind("::")
+            // +2 to skip the ::
+            .map(|v| v + 2)
+            .unwrap_or(0);
 
         SpectaID {
-            type_name: &type_name[0..last_segment],
+            type_name: &type_name[start_offset..end_offset],
             tid: non_static_type_id::<T>(),
         }
     }

--- a/tests/duplicate_ty_name.rs
+++ b/tests/duplicate_ty_name.rs
@@ -39,14 +39,14 @@ fn test_duplicate_ty_name() {
     #[cfg(not(target_os = "windows"))]
     let err = Err(ExportError::DuplicateTypeName(
         "One".into(),
-        impl_location("tests/duplicate_ty_name.rs:19:14"),
         impl_location("tests/duplicate_ty_name.rs:9:14"),
+        impl_location("tests/duplicate_ty_name.rs:19:14"),
     ));
     #[cfg(target_os = "windows")]
     let err = Err(ExportError::DuplicateTypeName(
         "One".into(),
-        impl_location("tests\\duplicate_ty_name.rs:19:14"),
         impl_location("tests\\duplicate_ty_name.rs:9:14"),
+        impl_location("tests\\duplicate_ty_name.rs:19:14"),
     ));
 
     assert_eq!(export::<Demo>(&Default::default()), err);


### PR DESCRIPTION
Hack around the `'static` bound on Rust's built-in `TypeId` to allow the ID to be tied to a compiler intrinsic instead of the implementation location of the macro like it currently issues.

<del>

Issues blocking merge:
  - Lack of const traits or a workaround a non `'static` `TypeId` without them
 - or remove `NamedType::SID` which I could see happening.

</del>