### PR TITLE
fix(macros): enumerate after filtering

### DIFF
--- a/specta-macros/src/type/enum.rs
+++ b/specta-macros/src/type/enum.rs
@@ -23,11 +23,11 @@ pub fn parse_enum(
     let generic_idents = generics
         .params
         .iter()
-        .enumerate()
-        .filter_map(|(i, p)| match p {
-            GenericParam::Type(t) => Some((i, &t.ident)),
+        .filter_map(|p| match p {
+            GenericParam::Type(t) => Some(&t.ident),
             _ => None,
-        });
+        })
+        .enumerate();
 
     let definition_generics = generic_idents.clone().map(|(_, ident)| {
         let ident = ident.to_string();

--- a/specta-macros/src/type/struct.rs
+++ b/specta-macros/src/type/struct.rs
@@ -46,11 +46,11 @@ pub fn parse_struct(
     let generic_idents = generics
         .params
         .iter()
-        .enumerate()
-        .filter_map(|(i, p)| match p {
-            GenericParam::Type(t) => Some((i, &t.ident)),
+        .filter_map(|p| match p {
+            GenericParam::Type(t) => Some(&t.ident),
             _ => None,
         })
+        .enumerate()
         .collect::<Vec<_>>();
 
     let reference_generics = generic_idents.iter().map(|(i, ident)| {


### PR DESCRIPTION
this fixes #287. it just swaps the order of operations to filtering out non-type generic params, _then_ enumerating them, within specta_macros' `parse_struct()` and `parse_enum()`. this affects no other parts of the codebase because the output of this operation is only ever (directly or indirectly) consumed in places where filter-then-enumerate is semantically correct (struct: [1](https://github.com/specta-rs/specta/blob/8509af0162b26bb2c08e84a41cdfc4eaf67a6ab3/specta-macros/src/type/struct.rs#L269), [2](https://github.com/specta-rs/specta/blob/8509af0162b26bb2c08e84a41cdfc4eaf67a6ab3/specta-macros/src/type/struct.rs#L274), [3](https://github.com/specta-rs/specta/blob/8509af0162b26bb2c08e84a41cdfc4eaf67a6ab3/specta-macros/src/type/struct.rs#L279), [4](https://github.com/specta-rs/specta/blob/8509af0162b26bb2c08e84a41cdfc4eaf67a6ab3/specta-macros/src/type/struct.rs#L283), enum: [1](https://github.com/specta-rs/specta/blob/8509af0162b26bb2c08e84a41cdfc4eaf67a6ab3/specta-macros/src/type/enum.rs#L236), [2](https://github.com/specta-rs/specta/blob/8509af0162b26bb2c08e84a41cdfc4eaf67a6ab3/specta-macros/src/type/enum.rs#L238)) or passed to `generics::construct_datatype()` (struct: [1](https://github.com/specta-rs/specta/blob/8509af0162b26bb2c08e84a41cdfc4eaf67a6ab3/specta-macros/src/type/struct.rs#L140), [2](https://github.com/specta-rs/specta/blob/8509af0162b26bb2c08e84a41cdfc4eaf67a6ab3/specta-macros/src/type/struct.rs#L181), [3](https://github.com/specta-rs/specta/blob/8509af0162b26bb2c08e84a41cdfc4eaf67a6ab3/specta-macros/src/type/struct.rs#L245), enum: [1](https://github.com/specta-rs/specta/blob/8509af0162b26bb2c08e84a41cdfc4eaf67a6ab3/specta-macros/src/type/enum.rs#L112), [2](https://github.com/specta-rs/specta/blob/8509af0162b26bb2c08e84a41cdfc4eaf67a6ab3/specta-macros/src/type/enum.rs#L171)), which then only ever passes it recursively to itself ([1](https://github.com/specta-rs/specta/blob/8509af0162b26bb2c08e84a41cdfc4eaf67a6ab3/specta-macros/src/type/generics.rs#L115), [2](https://github.com/specta-rs/specta/blob/8509af0162b26bb2c08e84a41cdfc4eaf67a6ab3/specta-macros/src/type/generics.rs#L139), [3](https://github.com/specta-rs/specta/blob/8509af0162b26bb2c08e84a41cdfc4eaf67a6ab3/specta-macros/src/type/generics.rs#L143), [4](https://github.com/specta-rs/specta/blob/8509af0162b26bb2c08e84a41cdfc4eaf67a6ab3/specta-macros/src/type/generics.rs#L159), [5](https://github.com/specta-rs/specta/blob/8509af0162b26bb2c08e84a41cdfc4eaf67a6ab3/specta-macros/src/type/generics.rs#L227)), or uses it in a way that is semantically correct ([1](https://github.com/specta-rs/specta/blob/8509af0162b26bb2c08e84a41cdfc4eaf67a6ab3/specta-macros/src/type/generics.rs#L196)). very good!