### PR TITLE
Update glam

### DIFF
--- a/specta/Cargo.toml
+++ b/specta/Cargo.toml
@@ -112,7 +112,7 @@ bit-vec = { version = "0.7.0", optional = true, default-features = false, featur
 bson = { version = "2.11.0", optional = true, default-features = false, features = [] }
 uhlc = { version = "0.8.0", optional = true, default-features = false, features = [] }
 bytesize = { version = "1.3.0", optional = true, default-features = false, features = [] }
-glam = { version = "0.28", optional = true, default-features = false, features = ["std"] }
+glam = { version = "0.29", optional = true, default-features = false, features = ["std"] }
 tokio = { version = "1.38", optional = true, default-features = false, features = ["sync"] }
 url = { version = "2.5.2", optional = true, default-features = false }
 either = { version = "1.13.0", optional = true, default-features = false }


### PR DESCRIPTION
Update to glam 0.29. Required for https://github.com/graphiteeditor/graphite.