### PR TITLE
Wrap maps in Partial<> in generated TypeScript types

### DIFF
--- a/examples/examples/basic.rs
+++ b/examples/examples/basic.rs
@@ -58,6 +58,6 @@ fn main() {
     println!("{ts_str}");
     assert_eq!(
         ts_str,
-        r#"export type Something = { a: { [key in MyEnum]: number } }"#.to_string()
+        r#"export type Something = { a: Partial<{ [key in MyEnum]: number }>"#.to_string()
     );
 }

--- a/specta-typescript/src/lib.rs
+++ b/specta-typescript/src/lib.rs
@@ -291,8 +291,9 @@ pub(crate) fn datatype_inner(
             }
         }
         DataType::Map(def) => {
-            // We use this instead of `Record<K, V>` to avoid issues with circular references.
-            s.push_str("{ [key in ");
+            // We use `{ [key in K]: V }` instead of `Record<K, V>` to avoid issues with circular references.
+            // Wrapped in Partial<> because otherwise TypeScript would enforce exhaustiveness.
+            s.push_str("Partial<{ [key in ");
             datatype_inner(
                 ctx.clone(),
                 &FunctionResultVariant::Value(def.key_ty().clone()),
@@ -306,7 +307,7 @@ pub(crate) fn datatype_inner(
                 type_map,
                 s,
             )?;
-            s.push_str(" }");
+            s.push_str(" }>");
         }
         // We use `T[]` instead of `Array<T>` to avoid issues with circular references.
         DataType::List(def) => {

--- a/tests/tests/advanced_types.rs
+++ b/tests/tests/advanced_types.rs
@@ -38,11 +38,11 @@ fn test_type_aliases() {
     assert_ts!(FullGeneric<u8, bool>, "{ a: number; b: boolean }");
     assert_ts!(Another<bool>, "{ a: number; b: boolean }");
 
-    assert_ts!(MapA<u32>, "{ [key in string]: number }");
-    assert_ts!(MapB<u32>, "{ [key in number]: string }");
+    assert_ts!(MapA<u32>, "Partial<{ [key in string]: number }>");
+    assert_ts!(MapB<u32>, "Partial<{ [key in number]: string }>");
     assert_ts!(
         MapC<u32>,
-        "{ [key in string]: { field: Demo<number, boolean> } }"
+        "Partial<{ [key in string]: { field: Demo<number, boolean> } }>"
     );
 
     assert_ts!(Struct<u32>, "{ field: Demo<number, boolean> }");

--- a/tests/tests/flatten_and_inline.rs
+++ b/tests/tests/flatten_and_inline.rs
@@ -118,7 +118,7 @@ pub enum K {
 fn serde() {
     assert_ts!(
         B,
-        "({ a: string }) & ({ [key in string]: string }) & ({ a: string })"
+        "({ a: string }) & (Partial<{ [key in string]: string }>) & ({ a: string })"
     );
     assert_ts!(C, "({ a: string }) & { b: { a: string } }");
     assert_ts!(D, "({ a: string }) & { b: { a: string }; type: \"D\" }");

--- a/tests/tests/map_keys.rs
+++ b/tests/tests/map_keys.rs
@@ -75,28 +75,28 @@ pub struct InvalidMaybeValidKeyNested(HashMap<MaybeValidKey<MaybeValidKey<()>>, 
 
 #[test]
 fn map_keys() {
-    assert_ts!(HashMap<String, ()>, "{ [key in string]: null }");
-    assert_ts_export!(Regular, "export type Regular = { [key in string]: null }");
-    assert_ts!(HashMap<Infallible, ()>, "{ [key in never]: null }");
-    assert_ts!(HashMap<Any, ()>, "{ [key in any]: null }");
-    assert_ts!(HashMap<TransparentStruct, ()>, "{ [key in string]: null }");
-    assert_ts!(HashMap<UnitVariants, ()>, "{ [key in \"A\" | \"B\" | \"C\"]: null }");
-    assert_ts!(HashMap<UntaggedVariants, ()>, "{ [key in string | number]: null }");
+    assert_ts!(HashMap<String, ()>, "Partial<{ [key in string]: null }>");
+    assert_ts_export!(Regular, "export type Regular = Partial<{ [key in string]: null }>");
+    assert_ts!(HashMap<Infallible, ()>, "Partial<{ [key in never]: null }>");
+    assert_ts!(HashMap<Any, ()>, "Partial<{ [key in any]: null }>");
+    assert_ts!(HashMap<TransparentStruct, ()>, "Partial<{ [key in string]: null }>");
+    assert_ts!(HashMap<UnitVariants, ()>, "Partial<{ [key in \"A\" | \"B\" | \"C\"]: null }>");
+    assert_ts!(HashMap<UntaggedVariants, ()>, "Partial<{ [key in string | number]: null }>");
     assert_ts!(
         ValidMaybeValidKey,
-        "{ [key in MaybeValidKey<string>]: null }"
+        "Partial<{ [key in MaybeValidKey<string>]: null }>"
     );
     assert_ts_export!(
         ValidMaybeValidKey,
-        "export type ValidMaybeValidKey = { [key in MaybeValidKey<string>]: null }"
+        "export type ValidMaybeValidKey = Partial<{ [key in MaybeValidKey<string>]: null }>"
     );
     assert_ts!(
         ValidMaybeValidKeyNested,
-        "{ [key in MaybeValidKey<MaybeValidKey<string>>]: null }"
+        "Partial<{ [key in MaybeValidKey<MaybeValidKey<string>>]: null }>"
     );
     assert_ts_export!(
         ValidMaybeValidKeyNested,
-        "export type ValidMaybeValidKeyNested = { [key in MaybeValidKey<MaybeValidKey<string>>]: null }"
+        "export type ValidMaybeValidKeyNested = Partial<{ [key in MaybeValidKey<MaybeValidKey<string>>]: null }>"
     );
 
     assert_ts!(error; HashMap<() /* `null` */, ()>, SerdeError::InvalidMapKey);

--- a/tests/tests/recursive.rs
+++ b/tests/tests/recursive.rs
@@ -63,11 +63,11 @@ fn test_recursive_types() {
 
     assert_ts!(
         RecursiveMapValue,
-        "{ demo: { [key in string]: RecursiveMapValue } }"
+        "{ demo: Partial<{ [key in string]: RecursiveMapValue }> }"
     );
     assert_ts_export!(
         RecursiveMapValue,
-        "export type RecursiveMapValue = { demo: { [key in string]: RecursiveMapValue } }"
+        "export type RecursiveMapValue = { demo: Partial<{ [key in string]: RecursiveMapValue }> }"
     );
 }
 

--- a/tests/tests/serde/internally_tagged.rs
+++ b/tests/tests/serde/internally_tagged.rs
@@ -125,7 +125,7 @@ fn internally_tagged() {
     assert_ts!(error; A, SerdeError::InvalidInternallyTaggedEnum);
     assert_ts!(error; B, SerdeError::InvalidInternallyTaggedEnum);
     assert_ts!(error; C, SerdeError::InvalidInternallyTaggedEnum);
-    assert_ts!(D, "({ type: \"A\" } & { [key in string]: string })");
+    assert_ts!(D, "({ type: \"A\" } & Partial<{ [key in string]: string }>)");
     assert_ts!(E, "({ type: \"A\" })");
     assert_ts!(F, "({ type: \"A\" } & FInner)");
     assert_ts!(error; G, SerdeError::InvalidInternallyTaggedEnum);

--- a/tests/tests/serde/serde_json.rs
+++ b/tests/tests/serde/serde_json.rs
@@ -5,8 +5,8 @@ fn serde_json() {
 
     assert_ts!(
         serde_json::Value,
-        "null | boolean | number | string | JsonValue[] | { [key in string]: JsonValue }"
+        "null | boolean | number | string | JsonValue[] | Partial<{ [key in string]: JsonValue }>"
     );
-    assert_ts!(serde_json::Map<String, ()>, "{ [key in string]: null }");
+    assert_ts!(serde_json::Map<String, ()>, "Partial<{ [key in string]: null }>");
     assert_ts!(serde_json::Number, "number");
 }

--- a/tests/tests/serde/serde_yaml.rs
+++ b/tests/tests/serde/serde_yaml.rs
@@ -5,12 +5,12 @@ fn serde_yaml() {
 
     assert_ts!(
         serde_yaml::Value,
-        "null | boolean | number | string | YamlValue[] | unknown | { [key in string]: unknown }"
+        "null | boolean | number | string | YamlValue[] | unknown | Partial<{ [key in string]: unknown }>"
     );
     assert_ts!(serde_yaml::Mapping, "unknown");
     assert_ts!(
         serde_yaml::value::TaggedValue,
-        "{ [key in string]: unknown }"
+        "Partial<{ [key in string]: unknown }>"
     );
     assert_ts!(serde_yaml::Number, "number");
 }

--- a/tests/tests/serde/toml.rs
+++ b/tests/tests/serde/toml.rs
@@ -5,9 +5,9 @@ fn toml() {
 
     assert_ts!(
         toml::Value,
-        "string | number | boolean | Datetime | TomlValue[] | { [key in string]: TomlValue }"
+        "string | number | boolean | Datetime | TomlValue[] | Partial<{ [key in string]: TomlValue }>"
     );
-    assert_ts!(toml::map::Map<String, ()>, "{ [key in string]: null }");
+    assert_ts!(toml::map::Map<String, ()>, "Partial<{ [key in string]: null }>");
     assert_ts!(
         toml::value::Datetime,
         "{ $__toml_private_datetime: string }"

--- a/tests/tests/ts.rs
+++ b/tests/tests/ts.rs
@@ -145,7 +145,7 @@ fn typescript_types() {
     );
 
     assert_ts!(OverridenStruct, "{ overriden_field: string }");
-    assert_ts!(HasGenericAlias, r#"{ [key in number]: string }"#);
+    assert_ts!(HasGenericAlias, r#"Partial<{ [key in number]: string }>"#);
 
     assert_ts!(SkipVariant, "{ A: string }");
     assert_ts!(SkipVariant2, r#"{ tag: "A"; data: string }"#);
@@ -191,7 +191,7 @@ fn typescript_types() {
     );
 
     // https://github.com/oscartbeaumont/specta/issues/65
-    assert_ts!(HashMap<BasicEnum, ()>, r#"{ [key in "A" | "B"]: null }"#);
+    assert_ts!(HashMap<BasicEnum, ()>, r#"Partial<{ [key in "A" | "B"]: null }>"#);
 
     // https://github.com/oscartbeaumont/specta/issues/60
     assert_ts!(Option<Option<Option<Option<i32>>>>, r#"number | null"#);
@@ -226,10 +226,10 @@ fn typescript_types() {
         Ok(r#"{ secs: string; nanos: number }"#.into())
     );
 
-    assert_ts!(HashMap<BasicEnum, i32>, r#"{ [key in "A" | "B"]: number }"#);
+    assert_ts!(HashMap<BasicEnum, i32>, r#"Partial<{ [key in "A" | "B"]: number }>"#);
     assert_ts_export!(
         EnumReferenceRecordKey,
-        "export type EnumReferenceRecordKey = { a: { [key in BasicEnum]: number } }"
+        "export type EnumReferenceRecordKey = { a: Partial<{ [key in BasicEnum]: number }> }"
     );
 
     assert_ts!(

--- a/tests/tests/ts_rs/generics.rs
+++ b/tests/tests/ts_rs/generics.rs
@@ -56,7 +56,7 @@ fn test() {
 
     assert_ts_export!(
         Container1,
-        "export type Container1 = { foo: Generic1<number>; bar: Generic1<number>[]; baz: { [key in string]: Generic1<string> } }"
+        "export type Container1 = { foo: Generic1<number>; bar: Generic1<number>[]; baz: Partial<{ [key in string]: Generic1<string> }> }"
     );
 }
 

--- a/tests/tests/ts_rs/indexmap.rs
+++ b/tests/tests/ts_rs/indexmap.rs
@@ -17,6 +17,6 @@ fn indexmap() {
 
     assert_ts!(
         Indexes,
-        "{ map: { [key in string]: string }; indexset: string[] }"
+        "{ map: Partial<{ [key in string]: string }>; indexset: string[] }"
     );
 }


### PR DESCRIPTION
This map:
```rs
pub enum MyEnum {
    A,
    B,
    C,
}

pub struct Something {
    a: HashMap<MyEnum, i32>,
}
```

is currently converted to
```ts
export type MyEnum = "A" | "B" | "C"

export type Something = {
  a: { [key in MyEnum]: number }
}
```

But this means TS expects `a`'s keys to be exhaustive, which isn't the case on the Rust side. Wrapping the type in `Partial` would fix this:
```ts
export type Something = {
  a: Partial<{ [key in MyEnum]: number }>
}
```

I couldn't actually compile the tests to fully test this properly. But after commenting some stuff out I think I got it to pass all the relevant tests.