### PR TITLE
add support for `jiff`

### DIFF
--- a/specta/Cargo.toml
+++ b/specta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "specta"
 description = "Easily export your Rust types to other languages"
-version = "2.0.0-rc.21"
+version = "2.0.0-rc.22"
 authors = ["Oscar Beaumont <oscar@otbeaumont.me>"]
 edition = "2021"
 license = "MIT"
@@ -49,6 +49,8 @@ ulid = ["dep:ulid"]
 chrono = ["dep:chrono"]
 ## [time](https://docs.rs/time) crate
 time = ["dep:time"]
+# [jiff](https://docs.rs/jiff) crate
+jiff = ["dep:jiff"]
 ## [bigdecimal](https://docs.rs/bigdecimal) crate
 bigdecimal = ["dep:bigdecimal"]
 ## [rust_decimal](https://docs.rs/rust_decimal) crate
@@ -118,6 +120,7 @@ url = { version = "2.5.2", optional = true, default-features = false }
 either = { version = "1.13.0", optional = true, default-features = false }
 bevy_ecs = { version = "0.14.0", optional = true, default-features = false }
 bevy_input = { version = "0.14.0", optional = true, default-features = false }
+jiff = { version = "0.1", optional = true, default-features = false }
 
 [dev-dependencies]
 serde = { version = "1.0.204", features = ["derive"] } # TODO: Can we remove this?

--- a/specta/src/docs.md
+++ b/specta/src/docs.md
@@ -66,6 +66,7 @@ External types
 - `uuid` - [uuid](https://docs.rs/uuid) crate
 - `chrono` - [chrono](https://docs.rs/chrono) crate
 - `time` - [time](https://docs.rs/time) crate
+- `jiff` - [jiff](https://docs.rs/jiff) crate
 - `bigdecimal` - [bigdecimal](https://docs.rs/bigdecimal) crate
 - `rust_decimal` - [rust_decimal](https://docs.rs/rust_decimal) crate
 - `indexmap` - [indexmap](https://docs.rs/indexmap) crate

--- a/specta/src/type/legacy_impls.rs
+++ b/specta/src/type/legacy_impls.rs
@@ -260,6 +260,17 @@ impl_as!(
     time::Weekday as String
 );
 
+#[cfg(feature = "jiff")]
+impl_as!(
+    jiff::Timestamp as String
+    jiff::Zoned as String
+    jiff::Span as String
+    jiff::civil::Date as String
+    jiff::civil::Time as String
+    jiff::civil::DateTime as String
+    jiff::tz::TimeZone as String
+);
+
 #[cfg(feature = "bigdecimal")]
 impl_as!(bigdecimal::BigDecimal as String);
 


### PR DESCRIPTION
I like using the `jiff` datetime library in my applications instead of `chrono` or `time`. Here's a PR that adds support for this library.