### PR TITLE
Remove unused serde_yaml dependency from specta-typescript

### DIFF
--- a/specta-typescript/Cargo.toml
+++ b/specta-typescript/Cargo.toml
@@ -26,7 +26,6 @@ serde = ["dep:serde", "specta/serde"]
 specta = { version = "=2.0.0-rc.22", path = "../specta" }
 specta-serde = { version = "=0.0.9", path = "../specta-serde" }
 serde = { version = "1", default-features = false, optional = true }
-serde_yaml = "0.9.34"
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
It was added in 8968c797 and seemingly was only used for ad hoc debugging.
