### PR TITLE
Add a function to get TypeScript type without inlining

### DIFF
--- a/specta-typescript/src/primitives.rs
+++ b/specta-typescript/src/primitives.rs
@@ -90,6 +90,15 @@ pub fn export(
     Ok(result)
 }
 
+/// Generate an Typescript string for a specific [`DataType`].
+///
+/// See [`export`] for the list of things to consider when using this.
+pub fn refer(ts: &Typescript, types: &TypeCollection, dt: &DataType) -> Result<String, Error> {
+    let mut s = String::new();
+    datatype(&mut s, ts, types, &dt, vec![], false, None)?;
+    Ok(s)
+}
+
 /// Generate an inlined Typescript string for a specific [`DataType`].
 ///
 /// This methods leaves all the same things as the [`export`] method up to the user.

--- a/specta-typescript/src/primitives.rs
+++ b/specta-typescript/src/primitives.rs
@@ -93,7 +93,7 @@ pub fn export(
 /// Generate an Typescript string for a specific [`DataType`].
 ///
 /// See [`export`] for the list of things to consider when using this.
-pub fn refer(ts: &Typescript, types: &TypeCollection, dt: &DataType) -> Result<String, Error> {
+pub fn reference(ts: &Typescript, types: &TypeCollection, dt: &DataType) -> Result<String, Error> {
     let mut s = String::new();
     datatype(&mut s, ts, types, &dt, vec![], false, None)?;
     Ok(s)


### PR DESCRIPTION
In 2.0.0-rc.22, before the most recent API rework, it was possible
to generate a TypeScript type string for a given type without inlining
(for example, `Vec<MyEnum>` would produce `MyEnum[]` rather than
`("Variant1" | "Variant2")]]`)

This change adds this option back.
