### PR TITLE
Mark fields with skip_serializing_if as optional in TypeScript types

### DIFF
--- a/specta-macros/src/type/attr/field.rs
+++ b/specta-macros/src/type/attr/field.rs
@@ -40,7 +40,7 @@ impl_parse! {
         "skip" => out.skip = attr.parse_bool().unwrap_or(true),
         "skip_serializing" => out.skip = true,
         "skip_deserializing" => out.skip = true,
-        "skip_serializing_if" => out.optional = attr.parse_string()? == *"Option::is_none" || out.optional,
+        "skip_serializing_if" => out.optional = true,
         // Specta only attribute
         "optional" => out.optional = attr.parse_bool().unwrap_or(true),
         "default" => out.optional = attr.parse_bool().unwrap_or(true),


### PR DESCRIPTION
fixes #233 

I want to add more tests, but tests won't compile.