### PR TITLE
TypeTag

### DIFF
--- a/specta/src/datatype.rs
+++ b/specta/src/datatype.rs
@@ -22,7 +22,7 @@ pub use fields::{
 pub use function::Function;
 pub use list::List;
 pub use map::Map;
-pub use named::{DeprecatedType, NamedDataType};
+pub use named::{DeprecatedType, NamedDataType, TypeTag};
 pub use primitive::Primitive;
 pub use reference::{GenericReference, NamedReference, OpaqueReference, Reference};
 pub use r#struct::Struct;

--- a/specta/src/datatype/named.rs
+++ b/specta/src/datatype/named.rs
@@ -1,11 +1,11 @@
 use std::{borrow::Cow, collections::HashSet, panic::Location, sync::Arc};
 
 use crate::{
-    datatype::{
-        reference::{self, GenericReference, NamedId},
-        DataType, NamedDataTypeBuilder, NamedReference, Reference,
-    },
     TypeCollection,
+    datatype::{
+        DataType, NamedDataTypeBuilder, NamedReference, Reference,
+        reference::{self, GenericReference, NamedId},
+    },
 };
 
 /// A named type represents a non-primitive type capable of being exported as it's own named entity.
@@ -275,10 +275,17 @@ pub enum DeprecatedType {
     },
 }
 
+/// Semantic tags that exporters can use to produce richer target-language types.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum TypeTag {
+    /// Represents values that map naturally to JavaScript's `Date` type.
     Date,
+    /// Represents values that map naturally to JavaScript's `BigInt` type.
+    BigInt,
+    /// Represents values that map naturally to JavaScript's `Uint8Array` type.
+    UInt8Array,
+    /// A user-defined semantic tag.
     Custom(Cow<'static, str>),
 }
 

--- a/specta/src/type/impls.rs
+++ b/specta/src/type/impls.rs
@@ -154,6 +154,7 @@ const _: () = {
                 ));
 
                 ndt.inner = DataType::Struct(s);
+                ndt.tags_mut().insert(datatype::TypeTag::Date);
             }
         }
 

--- a/specta/src/type/legacy_impls.rs
+++ b/specta/src/type/legacy_impls.rs
@@ -20,9 +20,22 @@ impl_ndt_as!(
 );
 
 #[cfg(feature = "bytes")]
-impl_ndt_as!(
-    bytes::Bytes as [u8]
-    bytes::BytesMut as [u8]
+impl_ndt!(
+    impl Type for bytes::Bytes {
+        inline: true;
+        build: |types, ndt| {
+            ndt.inner = <[u8]>::definition(types);
+            ndt.tags_mut().insert(datatype::TypeTag::UInt8Array);
+        }
+    }
+
+    impl Type for bytes::BytesMut {
+        inline: true;
+        build: |types, ndt| {
+            ndt.inner = <[u8]>::definition(types);
+            ndt.tags_mut().insert(datatype::TypeTag::UInt8Array);
+        }
+    }
 );
 
 #[cfg(feature = "serde_json")]
@@ -231,7 +244,8 @@ const _: () = {
                         attributes: Vec::new(),
                     }),
                     attributes: Vec::new(),
-                })
+                });
+                ndt.tags_mut().insert(datatype::TypeTag::Date);
             }
         }
 
@@ -305,10 +319,26 @@ impl_ndt_as!(
 #[allow(deprecated)]
 const _: () = {
     impl_ndt_as!(
-        chrono::NaiveDateTime as str
-        chrono::NaiveDate as str
         chrono::NaiveTime as str
         chrono::Duration as str
+    );
+
+    impl_ndt!(
+        impl Type for chrono::NaiveDateTime {
+            inline: true;
+            build: |types, ndt| {
+                ndt.inner = str::definition(types);
+                ndt.tags_mut().insert(datatype::TypeTag::Date);
+            }
+        }
+
+        impl Type for chrono::NaiveDate {
+            inline: true;
+            build: |types, ndt| {
+                ndt.inner = str::definition(types);
+                ndt.tags_mut().insert(datatype::TypeTag::Date);
+            }
+        }
     );
 
     // This is special cause of how it ignores the `generics` param to `NamedDataType::init_with_sentinel`
@@ -329,6 +359,7 @@ const _: () = {
                         ndt.set_name(::std::borrow::Cow::Borrowed(stringify!($type_name)));
                         ndt.set_module_path(::std::borrow::Cow::Borrowed(stringify!($module)));
                         ndt.inner = str::definition(types);
+                        ndt.tags_mut().insert(datatype::TypeTag::Date);
                     },
                 ))
             }
@@ -345,23 +376,78 @@ const _: () = {
 
 #[cfg(feature = "time")]
 impl_ndt_as!(
-    time::PrimitiveDateTime as str
-    time::OffsetDateTime as str
-    time::Date as str
     time::Time as str
     time::Duration as str
     time::Weekday as str
 );
 
+#[cfg(feature = "time")]
+impl_ndt!(
+    impl Type for time::PrimitiveDateTime {
+        inline: true;
+        build: |types, ndt| {
+            ndt.inner = str::definition(types);
+            ndt.tags_mut().insert(datatype::TypeTag::Date);
+        }
+    }
+
+    impl Type for time::OffsetDateTime {
+        inline: true;
+        build: |types, ndt| {
+            ndt.inner = str::definition(types);
+            ndt.tags_mut().insert(datatype::TypeTag::Date);
+        }
+    }
+
+    impl Type for time::Date {
+        inline: true;
+        build: |types, ndt| {
+            ndt.inner = str::definition(types);
+            ndt.tags_mut().insert(datatype::TypeTag::Date);
+        }
+    }
+);
+
 #[cfg(feature = "jiff")]
 impl_ndt_as!(
-    jiff::Timestamp as str
-    jiff::Zoned as str
     jiff::Span as str
-    jiff::civil::Date as str
     jiff::civil::Time as str
-    jiff::civil::DateTime as str
     jiff::tz::TimeZone as str
+);
+
+#[cfg(feature = "jiff")]
+impl_ndt!(
+    impl Type for jiff::Timestamp {
+        inline: true;
+        build: |types, ndt| {
+            ndt.inner = str::definition(types);
+            ndt.tags_mut().insert(datatype::TypeTag::Date);
+        }
+    }
+
+    impl Type for jiff::Zoned {
+        inline: true;
+        build: |types, ndt| {
+            ndt.inner = str::definition(types);
+            ndt.tags_mut().insert(datatype::TypeTag::Date);
+        }
+    }
+
+    impl Type for jiff::civil::Date {
+        inline: true;
+        build: |types, ndt| {
+            ndt.inner = str::definition(types);
+            ndt.tags_mut().insert(datatype::TypeTag::Date);
+        }
+    }
+
+    impl Type for jiff::civil::DateTime {
+        inline: true;
+        build: |types, ndt| {
+            ndt.inner = str::definition(types);
+            ndt.tags_mut().insert(datatype::TypeTag::Date);
+        }
+    }
 );
 
 #[cfg(feature = "bigdecimal")]
@@ -392,8 +478,18 @@ impl_ndt_as!(
 impl_ndt_as!(
     bson::oid::ObjectId as str
     bson::Decimal128 as i128
-    bson::DateTime as str
     bson::Uuid as str
+);
+
+#[cfg(feature = "bson")]
+impl_ndt!(
+    impl Type for bson::DateTime {
+        inline: true;
+        build: |types, ndt| {
+            ndt.inner = str::definition(types);
+            ndt.tags_mut().insert(datatype::TypeTag::Date);
+        }
+    }
 );
 
 // TODO: bson::bson


### PR DESCRIPTION
An experiment into one possible version of Nuanced Types.

TODO:
 - [ ] Apply tags to custom types via macro
 - [ ] Update built-in impls
 - [ ] Tauri Specta implementation of `Date` logic
 - [ ] Comments on `TypeTag`. We probs need to define specific serialization requirements.
 - [ ] Can we support `UInt8Array`/etc from `Vec<_>` types - specta-rs/tauri-specta#194

Brain dump:
 - Setting tags is probs unsafe like bigint. Should we show that in the mutation part of the API?