### PR TITLE
drop `Flatten`

### DIFF
--- a/specta-macros/src/type/mod.rs
+++ b/specta-macros/src/type/mod.rs
@@ -85,13 +85,6 @@ pub fn derive(input: proc_macro::TokenStream) -> syn::Result<proc_macro::TokenSt
     let type_args = generics_with_ident_only(generics);
     let where_bound = add_type_to_where_clause(&quote!(#crate_ref::Type), generics);
 
-    let flatten_impl = can_flatten.then(|| {
-        quote! {
-            #[automatically_derived]
-            impl #bounds #crate_ref::Flatten for #ident #type_args #where_bound {}
-        }
-    });
-
     let shadow_generics = {
         let g = generics.params.iter().map(|param| match param {
             // Pulled from outside
@@ -194,8 +187,6 @@ pub fn derive(input: proc_macro::TokenStream) -> syn::Result<proc_macro::TokenSt
                     )
                 }
             }
-
-            #flatten_impl
 
             #export
         };

--- a/specta/src/internal.rs
+++ b/specta/src/internal.rs
@@ -17,7 +17,7 @@ use crate::datatype::{DataType, Field};
 pub mod construct {
     use std::borrow::Cow;
 
-    use crate::{Flatten, Type, TypeCollection, datatype::*};
+    use crate::{Type, TypeCollection, datatype::*};
 
     pub fn skipped_field(
         optional: bool,
@@ -36,7 +36,8 @@ pub mod construct {
         }
     }
 
-    pub fn field_flattened<T: Type + Flatten>(
+    // TODO: Can we remove this method now that the `Flatten` trait doesn't need to be enforced???
+    pub fn field_flattened<T: Type>(
         optional: bool,
         inline: bool,
         deprecated: Option<DeprecatedType>,

--- a/specta/src/lib.rs
+++ b/specta/src/lib.rs
@@ -20,7 +20,7 @@ mod r#type;
 mod type_collection;
 
 // TODO: Can we just move the trait here or `#[doc(inline)]`
-pub use r#type::{Flatten, Type};
+pub use r#type::Type;
 pub use type_collection::TypeCollection;
 
 #[doc(inline)]

--- a/specta/src/type.rs
+++ b/specta/src/type.rs
@@ -16,6 +16,3 @@ pub trait Type {
     /// This will also register this and any dependent types into the [`TypeCollection`].
     fn definition(types: &mut TypeCollection) -> DataType;
 }
-
-/// A marker trait for compile-time validation of which types can be flattened.
-pub trait Flatten: Type {}

--- a/specta/src/type/impls.rs
+++ b/specta/src/type/impls.rs
@@ -199,18 +199,12 @@ impl<T: Type> Type for std::ops::Range<T> {
     }
 }
 
-impl<T: Type> Flatten for std::ops::Range<T> {}
-
 impl<T: Type> Type for std::ops::RangeInclusive<T> {
     impl_passthrough!(std::ops::Range<T>); // Yeah Serde are cringe
 }
 
-impl<T: Type> Flatten for std::ops::RangeInclusive<T> {}
-
 impl_for_map!(HashMap<K, V> as "HashMap");
 impl_for_map!(BTreeMap<K, V> as "BTreeMap");
-impl<K: Type, V: Type> Flatten for std::collections::HashMap<K, V> {}
-impl<K: Type, V: Type> Flatten for std::collections::BTreeMap<K, V> {}
 
 const _: () = {
     impl Type for std::time::SystemTime {
@@ -232,9 +226,6 @@ const _: () = {
             ))
         }
     }
-
-    #[automatically_derived]
-    impl Flatten for std::time::SystemTime {}
 };
 
 const _: () = {
@@ -257,6 +248,4 @@ const _: () = {
             ))
         }
     }
-
-    impl Flatten for std::time::Duration {}
 };

--- a/specta/src/type/legacy_impls.rs
+++ b/specta/src/type/legacy_impls.rs
@@ -1,6 +1,6 @@
 //! The plan is to try and move these into the ecosystem for the v2 release.
 use super::macros::*;
-use crate::{Flatten, Type, TypeCollection, datatype::*};
+use crate::{Type, TypeCollection, datatype::*};
 
 use std::borrow::Cow;
 
@@ -8,7 +8,6 @@ use std::borrow::Cow;
 const _: () = {
     impl_for_list!(true; indexmap::IndexSet<T> as "IndexSet");
     impl_for_map!(indexmap::IndexMap<K, V> as "IndexMap");
-    impl<K: Type, V: Type> Flatten for indexmap::IndexMap<K, V> {}
 };
 
 #[cfg(feature = "serde_json")]
@@ -16,7 +15,6 @@ const _: () = {
     use serde_json::{Map, Number, Value};
 
     impl_for_map!(Map<K, V> as "Map");
-    impl<K: Type, V: Type> Flatten for Map<K, V> {}
 
     #[derive(Type)]
     #[specta(rename = "JsonValue", untagged, remote = Value, crate = crate, export = false)]
@@ -193,7 +191,6 @@ const _: () = {
     use toml::{Value, value::Array, value::Datetime, value::Table};
 
     impl_for_map!(toml::map::Map<K, V> as "Map");
-    impl<K: Type, V: Type> Flatten for toml::map::Map<K, V> {}
 
     #[derive(Type)]
     #[specta(rename = "TomlValue", untagged, remote = Value, crate = crate, export = false)]

--- a/specta/src/type/macros.rs
+++ b/specta/src/type/macros.rs
@@ -41,8 +41,6 @@ macro_rules! _impl_containers {
                 <T as Type>::definition(types)
             }
         }
-
-        impl<T: Flatten> Flatten for $container<T> {}
     )+}
 }
 


### PR DESCRIPTION
I don't know if i'm going to merge this but now that flattening is done at runtime this trait is probs not the best idea.

It also makes implementing `Type` in userspace more problematic. We have done is incorrect within Specta's internals and we know how it works so expecting others to get it right is not really viable.