### PR TITLE
Update documentation for renamed feature export->collect

### DIFF
--- a/specta-swift/src/lib.rs
+++ b/specta-swift/src/lib.rs
@@ -7,7 +7,7 @@
 //! Add `specta`, `specta-serde`, and `specta-swift` to your project:
 //!
 //! ```bash
-//! cargo add specta@2.0.0-rc.24 --features derive,export
+//! cargo add specta@2.0.0-rc.24 --features derive,collect
 //! cargo add specta-serde@0.0.11
 //! cargo add specta-swift@0.0.2
 //! ```

--- a/specta-typescript/src/lib.rs
+++ b/specta-typescript/src/lib.rs
@@ -5,7 +5,7 @@
 //! Add `specta` and `specta-typescript` to your project:
 //!
 //! ```bash
-//! cargo add specta@2.0.0-rc.24 --features derive,export
+//! cargo add specta@2.0.0-rc.24 --features derive,collect
 //! cargo add specta-typescript@0.0.11
 //! cargo add specta-serde@0.0.11
 //! ```


### PR DESCRIPTION
According to https://github.com/specta-rs/specta/releases/tag/v2.0.0-rc.23, the `export` feature was renamed to `collect`. This is not yet reflected in the documentation, which leads to errors when trying to install via the provided command. 