### PR TITLE
specta-typescript: accept define() opaques as serde_json map keys

### DIFF
--- a/specta-typescript/src/map_keys.rs
+++ b/specta-typescript/src/map_keys.rs
@@ -157,10 +157,24 @@ fn validate_map_key_inner(
             result
         }
         DataType::Generic(_) => Ok(()),
-        DataType::Reference(Reference::Opaque(_)) => Err(Error::invalid_map_key(
-            path,
-            "opaque references cannot be validated as serde_json map keys",
-        )),
+        DataType::Reference(Reference::Opaque(r)) => {
+            // `define(literal)` is the user-facing escape hatch for inserting a
+            // verbatim TypeScript expression into the type graph. Treat it as
+            // valid for map keys -- the caller is asserting that `literal` is
+            // a serializable JSON map key, and rejecting it forces them to
+            // duplicate the bigint-style rewrite already done by libraries
+            // like taurpc (which converts `i64` -> `define("number")` to
+            // satisfy the BigInt-forbidden filter). Other opaque flavors --
+            // Tauri channels, branded types -- still fail loudly.
+            if r.downcast_ref::<crate::opaque::Define>().is_some() {
+                Ok(())
+            } else {
+                Err(Error::invalid_map_key(
+                    path,
+                    "opaque references cannot be validated as serde_json map keys",
+                ))
+            }
+        }
         DataType::Tuple(_) => Err(Error::invalid_map_key(
             path,
             "tuple keys are not supported by serde_json map key serialization",


### PR DESCRIPTION
## Summary

Hi! Sharing a small `validate_map_key` adjustment that came up while doing rc.24 work in a downstream taurpc fork.

`validate_map_key_inner` currently bails on every `Reference::Opaque` with:

```
opaque references cannot be validated as serde_json map keys
```

The cautious fallback makes sense for unknown opaques (Tauri channels, branded types, `Any` / `Unknown` / `Never` -- where the rendered TS isn't necessarily JSON-serializable as a key). But it also catches `Reference::Opaque(Define(literal))`, where the caller has already stated what TS expression they want emitted. For most of the typical things people put in `define()` -- `"number"`, `"string"`, `"bigint"`, string-literal unions, etc. -- the rendered TS is perfectly fine as `{[key in K]: V}`'s `K`.

The case that nudged me here: taurpc rewrites bigint primitives to `define("number")` to satisfy `primitive_dt`'s bigint-forbidden filter. After that rewrite, `HashMap<i64, V>` (or anything wrapping it -- `IndexMap<i64, T>` came up for me via `#[specta(type = IndexMap<i64, T>)]` on `IntervalTree<OffsetDateTime, T>`) becomes `HashMap<Reference::Opaque(Define("number")), V>` and surfaces as `Invalid map key at 'HashMap.<map_key>': opaque references cannot be validated as serde_json map keys`. The intended TS output (`{[key in number]: V}`) is valid; just the validator was being a touch too defensive.

This patch accepts `Reference::Opaque(Define(_))` as a valid map key while leaving the rejection in place for the other opaque flavors, so the diagnostic still fires where it's load-bearing. Open to a different framing -- happy to gate it behind an explicit opt-in on `Define`, or restrict to a known set of literals (`number`, `string`, `boolean`), if you'd prefer something more conservative.

## Notes

- Existing tests still pass (`cargo test -p specta-typescript`).
- Could fold this in with the (possibly unrelated) thought that the `path` argument the validator builds is sometimes just `HashMap.<map_key>` -- when a Map is rendered at the top of an inline expansion (e.g. a function arg/return), `map_key_path(&[])` returns `"HashMap"` and the parent type isn't in the path. Threading parent context in would have saved me a couple hours of bisecting; happy to spin that off as a separate PR if it'd be useful.

Thanks for all the work on rc.24 -- the `apply_phases` flow plus the strictness around BigInt has caught several real bugs in our type graph already.

## Test plan

- [x] `cargo test -p specta-typescript` (11 passed)
- [x] End-to-end: with this patch + the corresponding taurpc-side change ([fltsci/TauRPC#19](https://github.com/fltsci/TauRPC/pull/19)), our rc.24 typegen runs to completion. Either patch alone fixes the symptom for our case; both together leave no foot-gun.