### PR TITLE
fix: enable glam "all-types" feature for glam 0.33 compatibility

### DIFF
--- a/specta/Cargo.toml
+++ b/specta/Cargo.toml
@@ -141,7 +141,7 @@ bson = { version = "3", optional = true, default-features = false, features = ["
 bytes = { version = "1", optional = true, default-features = false, features = [] }
 uhlc = { version = "0.9", optional = true, default-features = false, features = [] }
 bytesize = { version = "2", optional = true, default-features = false, features = [] }
-glam = { version = "0.33", optional = true, default-features = false, features = ["std"] }
+glam = { version = "0.33", optional = true, default-features = false, features = ["std", "all-types"] }
 tokio = { version = "1", optional = true, default-features = false, features = ["sync"] }
 url = { version = "2", optional = true, default-features = false }
 either = { version = "1", optional = true, default-features = false }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -28,7 +28,7 @@ insta = "1.48.0"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 either = { version = "1.16", default-features = false }
 ulid = { version = "1.2", default-features = false, features = [] }
-glam = { version = "0.33", default-features = false, features = ["std"] }
+glam = { version = "0.33", default-features = false, features = ["std", "all-types"] }
 ordered-float = { version = ">=3, <6", default-features = false }
 heapless = { version = ">=0.7, <0.10", default-features = false }
 semver = { version = "1", default-features = false }


### PR DESCRIPTION
## Problem

CI went red on `main` after the glam `0.32 → 0.33` bump in the dependabot `specta-deps` group update (#493). `cargo build --all-features` fails with ~40 `error[E0425]: cannot find type ... in crate glam` errors in `specta/src/type/legacy_impls.rs` — every f64 (`DVec*`, `DMat*`, `DQuat`, `DAffine*`), integer (`I8Vec*` … `U64Vec*`, `IVec*`, `UVec*`), and size vector type.

## Root cause

glam 0.33 [made all types except `f32` and `bool` optional](https://github.com/bitshifter/glam-rs/blob/main/CHANGELOG.md), enabled by default through the new `all-types` feature group, to cut compile times:

> All types apart from `f32` and `bool` types are now optional but enabled by default. Unused types can be disabled to improve compile times.

specta declares glam with `default-features = false`, which opts out of that default `all-types` group, so the double-precision and integer type impls in `legacy_impls.rs` stopped resolving.

## Fix

Add `"all-types"` to the glam features in the two crates that rely on those impls:

- `specta/Cargo.toml`
- `tests/Cargo.toml`

Two-line change; `Cargo.lock` is unaffected (a feature toggle doesn't move the lock).

## Testing

Full [contributor guide](CONTRIBUTORS.md) checklist, all green locally (glam resolved to 0.33.2):

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-features` — clean
- [x] `cargo test --all-features` — 94 passed, 0 failed
- [x] `cargo build --all --no-default-features`
- [x] `cargo build --all-features`

No snapshot or trybuild changes.
