### PR TITLE
Restore reference rendering for arbitrary datatypes

### DIFF
--- a/specta-typescript/src/exporter.rs
+++ b/specta-typescript/src/exporter.rs
@@ -844,18 +844,12 @@ impl BrandedTypeExporter<'_> {
         primitives::inline(self, self.types, &mapped)
     }
 
-    /// [primitives::reference]
-    pub fn reference(&self, r: &Reference) -> Result<String, Error> {
-        let mapped = map_datatype_format(
-            self.format,
-            self.types,
-            &DataType::Reference(r.clone()),
-            &[],
-        )?;
-        match mapped {
-            DataType::Reference(reference) => primitives::reference(self, self.types, &reference),
-            dt => primitives::inline(self, self.types, &dt),
-        }
+    /// Render a datatype while recursively preserving ordinary named references.
+    ///
+    /// See [`primitives::reference`] for details.
+    pub fn reference(&self, dt: &DataType) -> Result<String, Error> {
+        let mapped = map_datatype_format(self.format, self.types, dt, &[])?;
+        primitives::reference(self, self.types, &mapped)
     }
 }
 
@@ -914,18 +908,12 @@ impl FrameworkExporter<'_> {
         primitives::inline(self, self.types, &mapped)
     }
 
-    /// [primitives::reference]
-    pub fn reference(&self, r: &Reference) -> Result<String, Error> {
-        let mapped = map_datatype_format(
-            self.format,
-            self.types,
-            &DataType::Reference(r.clone()),
-            &[],
-        )?;
-        match mapped {
-            DataType::Reference(reference) => primitives::reference(self, self.types, &reference),
-            dt => primitives::inline(self, self.types, &dt),
-        }
+    /// Render a datatype while recursively preserving ordinary named references.
+    ///
+    /// See [`primitives::reference`] for details.
+    pub fn reference(&self, dt: &DataType) -> Result<String, Error> {
+        let mapped = map_datatype_format(self.format, self.types, dt, &[])?;
+        primitives::reference(self, self.types, &mapped)
     }
 
     /// [primitives::export]

--- a/specta-typescript/src/primitives.rs
+++ b/specta-typescript/src/primitives.rs
@@ -727,15 +727,17 @@ fn jsdoc_description(docs: &str, deprecated: Option<&Deprecated>) -> Option<Stri
     }
 }
 
-/// Generate an Typescript string to refer to a specific [`DataType`].
+/// Generate a Typescript string for a specific [`DataType`] while preserving ordinary named
+/// references recursively.
 ///
-/// For primitives this will include the literal type but for named type it will contain a reference.
+/// Unlike [`inline`], named types are rendered as references even when nested within an anonymous
+/// composite type. References explicitly marked as inline are still expanded.
 ///
 /// See [`export`] for the list of things to consider when using this.
 pub fn reference(
     exporter: &dyn AsRef<Exporter>,
     types: &Types,
-    r: &Reference,
+    dt: &DataType,
 ) -> Result<String, Error> {
     let mut s = String::new();
     datatype(
@@ -743,7 +745,7 @@ pub fn reference(
         exporter.as_ref(),
         None,
         types,
-        &DataType::Reference(r.clone()),
+        dt,
         vec![],
         None,
         "",

--- a/tests/tests/functions.rs
+++ b/tests/tests/functions.rs
@@ -13,10 +13,7 @@ fn render_datatype(ts: &Typescript, types: &Types, dt: &DataType) -> String {
     let types = specta_serde::Format.map_types(types).unwrap();
     let dt = specta_serde::Format.map_type(&types, dt).unwrap();
 
-    match &*dt {
-        DataType::Reference(r) => primitives::reference(ts, &types, r).unwrap(),
-        dt => primitives::inline(ts, &types, dt).unwrap(),
-    }
+    primitives::reference(ts, &types, &dt).unwrap()
 }
 
 /// Multiline

--- a/tests/tests/jsdoc.rs
+++ b/tests/tests/jsdoc.rs
@@ -160,8 +160,12 @@ fn primitives_reference() {
                 };
 
                 Some(
-                    primitives::reference(&JSDoc::default(), &types, &reference)
-                        .map(|ty| format!("{name}: {ty}")),
+                    primitives::reference(
+                        &JSDoc::default(),
+                        &types,
+                        &DataType::Reference(reference),
+                    )
+                    .map(|ty| format!("{name}: {ty}")),
                 )
             })
             .collect::<Result<Vec<_>, _>>()

--- a/tests/tests/typescript.rs
+++ b/tests/tests/typescript.rs
@@ -131,6 +131,128 @@ fn typescript_with_raw_exports_with_framework_runtime() {
 }
 
 #[test]
+fn framework_runtime_can_reference_composites_without_inlining() {
+    // https://github.com/specta-rs/tauri-specta/issues/228
+    #[derive(Type)]
+    #[specta(collect = false)]
+    struct Thing {
+        value: String,
+    }
+
+    #[derive(Type)]
+    #[specta(collect = false)]
+    struct Wrapper<T> {
+        value: T,
+    }
+
+    #[derive(Type)]
+    #[specta(collect = false)]
+    struct ExplicitlyInline {
+        #[specta(inline)]
+        thing: Thing,
+    }
+
+    #[derive(Type)]
+    #[specta(collect = false)]
+    struct Recursive {
+        child: Option<Box<Recursive>>,
+    }
+
+    let mut types = Types::default();
+    let thing = Thing::definition(&mut types);
+    let optional = Option::<Thing>::definition(&mut types);
+    let list = Vec::<Thing>::definition(&mut types);
+    let map = HashMap::<String, Thing>::definition(&mut types);
+    let tuple = <(Thing, Thing)>::definition(&mut types);
+    let intersection = DataType::Intersection(vec![thing.clone(), thing.clone()]);
+    let generic = Wrapper::<Thing>::definition(&mut types);
+    let recursive = Option::<Recursive>::definition(&mut types);
+    let explicitly_inline = ExplicitlyInline::definition(&mut types);
+    let explicitly_inline = match explicitly_inline {
+        DataType::Reference(Reference::Named(reference)) => {
+            types.get(&reference).unwrap().ty.clone().unwrap()
+        }
+        _ => panic!("expected named reference"),
+    };
+    let legacy_inline_optional =
+        primitives::inline(&Typescript::default(), &types, &optional).unwrap();
+
+    let output = Exporter::from(Typescript::default())
+        .framework_runtime(move |ctx| {
+            Ok(Cow::Owned(
+                [
+                    ("thing", &thing),
+                    ("optional", &optional),
+                    ("list", &list),
+                    ("map", &map),
+                    ("tuple", &tuple),
+                    ("intersection", &intersection),
+                    ("generic", &generic),
+                    ("recursive", &recursive),
+                    ("explicitly_inline", &explicitly_inline),
+                ]
+                .into_iter()
+                .map(|(name, dt)| Ok(format!("{name}: {}", ctx.reference(dt)?)))
+                .collect::<Result<Vec<_>, specta_typescript::Error>>()?
+                .join("\n"),
+            ))
+        })
+        .export(&types, specta_serde::Format)
+        .unwrap();
+
+    assert!(output.contains("thing: Thing"));
+    assert!(output.contains("optional: Thing | null"));
+    assert!(output.contains("list: Thing[]"));
+    assert!(output.contains("map: { [key in string]: Thing }"));
+    assert!(output.contains("tuple: [Thing, Thing]"));
+    assert!(output.contains("intersection: Thing & Thing"));
+    assert!(output.contains("generic: Wrapper<Thing>"));
+    assert!(output.contains("recursive: Recursive | null"));
+    assert!(
+        output.contains("explicitly_inline: {\n\tthing: {\n\t\tvalue: string,\n\t},\n}"),
+        "{output}"
+    );
+
+    assert_eq!(legacy_inline_optional, "{\n\tvalue: string,\n} | null");
+}
+
+#[test]
+fn framework_runtime_reference_tracks_nested_references_for_files_layout() {
+    // https://github.com/specta-rs/tauri-specta/issues/228
+    #[derive(Type)]
+    #[specta(collect = false)]
+    struct Thing {
+        value: String,
+    }
+
+    let mut types = Types::default();
+    let optional = Option::<Thing>::definition(&mut types);
+    let temp = Path::new(env!("CARGO_MANIFEST_DIR")).join(".temp");
+    std::fs::create_dir_all(&temp).unwrap();
+    let temp = TempDir::new_in(temp).unwrap();
+
+    Exporter::from(Typescript::default().layout(Layout::Files))
+        .framework_runtime(move |ctx| {
+            Ok(Cow::Owned(format!(
+                "export type Runtime = {};",
+                ctx.reference(&optional)?
+            )))
+        })
+        .export_to(temp.path(), &types, specta_serde::Format)
+        .unwrap();
+
+    let output = fs_to_string(temp.path()).unwrap();
+    assert!(
+        output.contains("import type * as test$typescript"),
+        "{output}"
+    );
+    assert!(
+        output.contains("export type Runtime = test$typescript.Thing | null;"),
+        "{output}"
+    );
+}
+
+#[test]
 fn typescript_with_raw_exports_to_files_layout() {
     let temp = Path::new(env!("CARGO_MANIFEST_DIR")).join(".temp");
     std::fs::create_dir_all(&temp).unwrap();
@@ -1085,8 +1207,12 @@ fn primitives_reference() {
                 };
 
                 Some(
-                    primitives::reference(&Typescript::default(), &types, &reference)
-                        .map(|ty| format!("{name}: {ty}")),
+                    primitives::reference(
+                        &Typescript::default(),
+                        &types,
+                        &DataType::Reference(reference),
+                    )
+                    .map(|ty| format!("{name}: {ty}")),
                 )
             })
             .collect::<Result<Vec<_>, _>>()


### PR DESCRIPTION
## Summary

- restore `specta_typescript::primitives::reference` to accept arbitrary `DataType` values
- expose the same reference-preserving behavior through framework and branded exporter contexts
- preserve ordinary named references recursively while continuing to expand explicitly inline references
- add regression coverage for nullable, list, map, tuple, intersection, generic, recursive, explicit-inline, serde-formatted, and multi-file cases

## Context

[`tauri-specta#228`](https://github.com/specta-rs/tauri-specta/issues/228) exposes an API gap introduced when `reference` was narrowed to accept only `Reference`. Composite datatypes such as `Nullable<Reference<Thing>>` then had to be passed through `inline`, which deep-inlined the nullable child.

The internal normal datatype renderer already has the desired behavior and tracks layout imports correctly, so this restores the earlier public API around that path. Existing `inline` behavior remains unchanged.

## Validation

- `cargo test -p specta-tests` (107 passed)
- `cargo test -p specta-typescript` (18 doctests passed, 4 ignored)
- `cargo clippy -p specta-typescript --all-targets` (passes; reports three pre-existing warnings in `specta` core)
- independent reviewer-agent pass and confirming re-review: clean
