### PR TITLE
Fix specta-util selection and remapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,6 +1867,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "selection-no-direct-deps"
+version = "0.0.0"
+dependencies = [
+ "specta-util",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/selection-no-direct-deps/Cargo.toml
+++ b/examples/selection-no-direct-deps/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "selection-no-direct-deps"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+specta-util = { path = "../../specta-util", features = ["serde"] }

--- a/examples/selection-no-direct-deps/src/main.rs
+++ b/examples/selection-no-direct-deps/src/main.rs
@@ -1,0 +1,26 @@
+struct User {
+    serde: String,
+    specta: u32,
+}
+
+fn main() {
+    let selection = specta_util::selection!(
+        User {
+            serde: "Ada".to_owned(),
+            specta: 37,
+        },
+        { serde, specta } as __private
+    );
+    assert_eq!(selection.serde, "Ada");
+    assert_eq!(selection.specta, 37);
+
+    let selections = specta_util::selection!(
+        [User {
+            serde: "Grace".to_owned(),
+            specta: 85,
+        }],
+        [{ serde, specta }] as __private
+    );
+    assert_eq!(selections[0].serde, "Grace");
+    assert_eq!(selections[0].specta, 85);
+}

--- a/examples/selection-no-direct-deps/src/main.rs
+++ b/examples/selection-no-direct-deps/src/main.rs
@@ -3,6 +3,12 @@ struct User {
     specta: u32,
 }
 
+fn assert_selection_traits<T>(_: &T)
+where
+    T: specta_util::__private::serde::Serialize + specta_util::__private::specta::Type,
+{
+}
+
 fn main() {
     let selection = specta_util::selection!(
         User {
@@ -11,6 +17,7 @@ fn main() {
         },
         { serde, specta } as __private
     );
+    assert_selection_traits(&selection);
     assert_eq!(selection.serde, "Ada");
     assert_eq!(selection.specta, 37);
 
@@ -21,6 +28,7 @@ fn main() {
         }],
         [{ serde, specta }] as __private
     );
+    assert_selection_traits(&selections[0]);
     assert_eq!(selections[0].serde, "Grace");
     assert_eq!(selections[0].specta, 85);
 }

--- a/specta-util/Cargo.toml
+++ b/specta-util/Cargo.toml
@@ -20,7 +20,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = []
 
 ## Support for [serde](https://serde.rs)
-serde = ["dep:serde"]
+serde = ["dep:serde", "serde/derive", "specta/derive"]
 
 [lints]
 workspace = true

--- a/specta-util/Cargo.toml
+++ b/specta-util/Cargo.toml
@@ -20,7 +20,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = []
 
 ## Support for [serde](https://serde.rs)
-serde = ["dep:serde", "serde/derive", "specta/derive"]
+serde = ["dep:serde", "serde/derive", "serde/std", "specta/derive"]
 
 [lints]
 workspace = true

--- a/specta-util/src/lib.rs
+++ b/specta-util/src/lib.rs
@@ -13,5 +13,12 @@ mod selection;
 mod array;
 mod remapper;
 
+#[doc(hidden)]
+#[cfg(feature = "serde")]
+pub mod __private {
+    pub use serde;
+    pub use specta;
+}
+
 pub use array::FixedArray;
 pub use remapper::Remapper;

--- a/specta-util/src/remapper.rs
+++ b/specta-util/src/remapper.rs
@@ -58,7 +58,9 @@ impl Remapper {
 
     /// Registers a rule that replaces exact matches of `from` with `to`.
     ///
-    /// Rules are checked in the order they are registered.
+    /// Rules are checked in the order they are registered. Replacements are
+    /// recursively crawled, but a rule is not reapplied within the replacement
+    /// subtree it created. This allows rules such as `T -> Vec<T>` to terminate.
     pub fn rule(mut self, from: DataType, to: DataType) -> Self {
         self.rules.push((from, to));
         self
@@ -116,7 +118,8 @@ impl Remapper {
 
     /// Applies the remap operation to a datatype, returning the remapped datatype.
     pub fn remap_dt(&self, mut dt: DataType) -> DataType {
-        self.remap_internal(&mut dt);
+        let active_rules = vec![false; self.rules.len()];
+        self.remap_internal(&mut dt, &active_rules);
         dt
     }
 
@@ -125,86 +128,90 @@ impl Remapper {
         types.map(|mut ndt| {
             ndt.generics.to_mut().iter_mut().for_each(|generic| {
                 if let Some(dt) = &mut generic.default {
-                    self.remap_internal(dt);
+                    let active_rules = vec![false; self.rules.len()];
+                    self.remap_internal(dt, &active_rules);
                 }
             });
             if let Some(dt) = &mut ndt.ty {
-                self.remap_internal(dt);
+                let active_rules = vec![false; self.rules.len()];
+                self.remap_internal(dt, &active_rules);
             }
             ndt
         })
     }
 
-    fn remap_internal(&self, dt: &mut DataType) {
-        self.remap_rules(dt);
+    fn remap_internal(&self, dt: &mut DataType, active_rules: &[bool]) {
+        let mut active_rules = active_rules.to_vec();
+        self.remap_rules(dt, &mut active_rules);
 
         match dt {
             DataType::Primitive(_) | DataType::Generic(_) => {}
-            DataType::List(list) => self.remap_internal(&mut list.ty),
+            DataType::List(list) => self.remap_internal(&mut list.ty, &active_rules),
             DataType::Map(map) => {
-                self.remap_internal(map.key_ty_mut());
-                self.remap_internal(map.value_ty_mut());
+                self.remap_internal(map.key_ty_mut(), &active_rules);
+                self.remap_internal(map.value_ty_mut(), &active_rules);
             }
-            DataType::Struct(s) => self.remap_fields(&mut s.fields),
+            DataType::Struct(s) => self.remap_fields(&mut s.fields, &active_rules),
             DataType::Enum(e) => {
                 for (_, variant) in &mut e.variants {
-                    self.remap_fields(&mut variant.fields);
+                    self.remap_fields(&mut variant.fields, &active_rules);
                 }
             }
             DataType::Tuple(tuple) => {
                 for dt in &mut tuple.elements {
-                    self.remap_internal(dt);
+                    self.remap_internal(dt, &active_rules);
                 }
             }
-            DataType::Nullable(dt) => self.remap_internal(dt),
+            DataType::Nullable(dt) => self.remap_internal(dt, &active_rules),
             DataType::Intersection(dts) => {
                 for dt in dts {
-                    self.remap_internal(dt);
+                    self.remap_internal(dt, &active_rules);
                 }
             }
-            DataType::Reference(r) => self.remap_reference(r),
+            DataType::Reference(r) => self.remap_reference(r, &active_rules),
         }
     }
 
-    fn remap_rules(&self, dt: &mut DataType) {
-        for (from, to) in &self.rules {
-            if *dt == *from {
+    fn remap_rules(&self, dt: &mut DataType, active_rules: &mut [bool]) {
+        for (index, (from, to)) in self.rules.iter().enumerate() {
+            if !active_rules[index] && *dt == *from {
                 *dt = to.clone();
+                active_rules[index] = true;
             }
         }
     }
 
-    fn remap_fields(&self, fields: &mut Fields) {
+    fn remap_fields(&self, fields: &mut Fields, active_rules: &[bool]) {
         match fields {
             Fields::Unit => {}
             Fields::Unnamed(fields) => {
                 for field in &mut fields.fields {
                     if let Some(dt) = &mut field.ty {
-                        self.remap_internal(dt);
+                        self.remap_internal(dt, active_rules);
                     }
                 }
             }
             Fields::Named(fields) => {
                 for (_, field) in &mut fields.fields {
                     if let Some(dt) = &mut field.ty {
-                        self.remap_internal(dt);
+                        self.remap_internal(dt, active_rules);
                     }
                 }
             }
         }
     }
 
-    fn remap_reference(&self, reference: &mut Reference) {
+    fn remap_reference(&self, reference: &mut Reference, active_rules: &[bool]) {
         let Reference::Named(reference) = reference else {
             return;
         };
 
         match &mut reference.inner {
             NamedReferenceType::Recursive(_) => {}
-            NamedReferenceType::Inline { dt, .. } => self.remap_internal(dt),
+            NamedReferenceType::Inline { dt, .. } => self.remap_internal(dt, active_rules),
             NamedReferenceType::Reference { generics, .. } => {
                 for (_, dt) in generics {
-                    self.remap_internal(dt);
+                    self.remap_internal(dt, active_rules);
                 }
             }
         }
@@ -262,6 +269,18 @@ mod tests {
             .remap_dt(Primitive::u32.into());
 
         assert_eq!(remapped, DataType::List(List::new(Primitive::bool.into())));
+    }
+
+    #[test]
+    fn replacement_does_not_recrawl_the_rule_that_created_it() {
+        let remapped = Remapper::new()
+            .rule(
+                Primitive::u32.into(),
+                DataType::List(List::new(Primitive::u32.into())),
+            )
+            .remap_dt(Primitive::u32.into());
+
+        assert_eq!(remapped, DataType::List(List::new(Primitive::u32.into())));
     }
 
     #[test]

--- a/specta-util/src/selection.rs
+++ b/specta-util/src/selection.rs
@@ -35,7 +35,7 @@
 // TODO: better docs w/ example
 #[macro_export]
 macro_rules! selection {
-    ( $s:expr, { $($n:ident),+ $(,)? } as $name:ident ) => {{
+    ( @define { $($n:ident),+ } as $name:ident ) => {
         #[allow(non_camel_case_types)]
         mod selection {
             mod deps {
@@ -52,31 +52,27 @@ macro_rules! selection {
             }
         }
         use selection::definition::$name;
+    };
+    ( $s:ident, { $($n:ident),+ $(,)? } as $name:ident ) => {{
+        $crate::selection!(@define { $($n),+ } as $name);
+        #[allow(non_camel_case_types)]
+        $name { $($n: $s.$n,)* }
+    }};
+    ( $s:expr, { $($n:ident),+ $(,)? } as $name:ident ) => {{
+        $crate::selection!(@define { $($n),+ } as $name);
         #[allow(non_camel_case_types)]
         let value = $s;
         $name { $($n: value.$n,)* }
+    }};
+    ( $s:ident, { $($n:ident),+ $(,)? } ) => {{
+        $crate::selection!($s, { $($n),+ } as Selection)
     }};
     ( $s:expr, { $($n:ident),+ $(,)? } ) => {{
         $crate::selection!($s, { $($n),+ } as Selection)
     }};
 
     ( $s:expr, [{ $($n:ident),+ $(,)? }] as $name:ident ) => {{
-        #[allow(non_camel_case_types)]
-        mod selection {
-            mod deps {
-                pub use $crate::__private::{serde, specta};
-            }
-
-            pub mod definition {
-                #[derive(super::deps::serde::Serialize, super::deps::specta::Type)]
-                #[serde(crate = "super::deps::serde")]
-                #[specta(crate = super::deps::specta, inline)]
-                pub struct $name<$($n,)*> {
-                    $(pub $n: $n),*
-                }
-            }
-        }
-        use selection::definition::$name;
+        $crate::selection!(@define { $($n),+ } as $name);
         #[allow(non_camel_case_types)]
         $s.into_iter().map(|v| $name { $($n: v.$n,)* }).collect::<Vec<_>>()
     }};
@@ -92,6 +88,11 @@ mod tests {
     struct User {
         name: &'static str,
         age: u32,
+    }
+
+    struct Account {
+        name: String,
+        password: String,
     }
 
     #[test]
@@ -111,5 +112,17 @@ mod tests {
         assert_eq!(evaluations.get(), 1);
         assert_eq!(selection.name, "Ada");
         assert_eq!(selection.age, 37);
+    }
+
+    #[test]
+    fn struct_identifier_preserves_unselected_fields() {
+        let account = Account {
+            name: "Ada".to_owned(),
+            password: "correct horse".to_owned(),
+        };
+        let selection = crate::selection!(account, { name });
+
+        assert_eq!(selection.name, "Ada");
+        assert_eq!(account.password, "correct horse");
     }
 }

--- a/specta-util/src/selection.rs
+++ b/specta-util/src/selection.rs
@@ -1,5 +1,3 @@
-// TODO: Should `specta-util` rexport `specta` for these macros???
-
 /// Specta compatible selection of struct fields.
 ///
 /// ```ignore
@@ -40,15 +38,23 @@ macro_rules! selection {
     ( $s:expr, { $($n:ident),+ $(,)? } as $name:ident ) => {{
         #[allow(non_camel_case_types)]
         mod selection {
-            #[derive(serde::Serialize, specta::Type)]
-            #[specta(inline)]
-            pub struct $name<$($n,)*> {
-                $(pub $n: $n),*
+            mod deps {
+                pub use $crate::__private::{serde, specta};
+            }
+
+            pub mod definition {
+                #[derive(super::deps::serde::Serialize, super::deps::specta::Type)]
+                #[serde(crate = "super::deps::serde")]
+                #[specta(crate = super::deps::specta, inline)]
+                pub struct $name<$($n,)*> {
+                    $(pub $n: $n),*
+                }
             }
         }
-        use selection::$name;
+        use selection::definition::$name;
         #[allow(non_camel_case_types)]
-        $name { $($n: $s.$n,)* }
+        let value = $s;
+        $name { $($n: value.$n,)* }
     }};
     ( $s:expr, { $($n:ident),+ $(,)? } ) => {{
         $crate::selection!($s, { $($n),+ } as Selection)
@@ -57,17 +63,53 @@ macro_rules! selection {
     ( $s:expr, [{ $($n:ident),+ $(,)? }] as $name:ident ) => {{
         #[allow(non_camel_case_types)]
         mod selection {
-            #[derive(serde::Serialize, specta::Type)]
-            #[specta(inline)]
-            pub struct $name<$($n,)*> {
-                $(pub $n: $n),*
+            mod deps {
+                pub use $crate::__private::{serde, specta};
+            }
+
+            pub mod definition {
+                #[derive(super::deps::serde::Serialize, super::deps::specta::Type)]
+                #[serde(crate = "super::deps::serde")]
+                #[specta(crate = super::deps::specta, inline)]
+                pub struct $name<$($n,)*> {
+                    $(pub $n: $n),*
+                }
             }
         }
-        use selection::$name;
+        use selection::definition::$name;
         #[allow(non_camel_case_types)]
         $s.into_iter().map(|v| $name { $($n: v.$n,)* }).collect::<Vec<_>>()
     }};
     ( $s:expr, [{ $($n:ident),+ $(,)? }] ) => {{
         $crate::selection!($s, [{ $($n),+ }] as Selection)
     }};
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    struct User {
+        name: &'static str,
+        age: u32,
+    }
+
+    #[test]
+    fn struct_input_is_evaluated_once() {
+        let evaluations = Cell::new(0);
+        let selection = crate::selection!(
+            {
+                evaluations.set(evaluations.get() + 1);
+                User {
+                    name: "Ada",
+                    age: 37,
+                }
+            },
+            { name, age }
+        );
+
+        assert_eq!(evaluations.get(), 1);
+        assert_eq!(selection.name, "Ada");
+        assert_eq!(selection.age, 37);
+    }
 }


### PR DESCRIPTION
## Summary

- make `selection!` evaluate scalar inputs once
- make `selection!` self-contained for downstream crates without direct `serde` or derive-enabled `specta` dependencies
- prevent Remapper rules from recursively reapplying within their own replacement subtree while preserving cross-rule recrawling

## Root cause

The scalar macro substituted its input expression once per field and emitted caller-resolved derive paths. Remapper recursively revisited replacement children without tracking which rule created the active subtree.

## Validation

- `cargo test -p specta-util --all-features`
- `cargo check -p selection-no-direct-deps`
- `cargo clippy -p specta-util --all-features --all-targets --no-deps -- -D warnings`
- `cargo test --workspace`
- independent subagent review/fix loop: clean