### PR TITLE
Fix internally tagged serde payload lowering

### DIFF
--- a/specta-serde/src/lib.rs
+++ b/specta-serde/src/lib.rs
@@ -120,7 +120,10 @@ mod repr;
 mod validate;
 
 use inflection::RenameRule;
-use parser::{SerdeContainerAttrs, SerdeFieldAttrs, SerdeVariantAttrs};
+use parser::{
+    CONTAINER_FROM_RESOLVED, CONTAINER_INTO_RESOLVED, CONTAINER_TRY_FROM_RESOLVED,
+    SerdeContainerAttrs, SerdeFieldAttrs, SerdeVariantAttrs,
+};
 use phased::PhasedTy;
 use repr::EnumRepr;
 
@@ -3139,6 +3142,12 @@ pub(crate) fn internal_tag_payload_requires_contextual_rewrite_for_mode(
         seen: &mut HashSet<Reference>,
         mode: PhaseRewrite,
     ) -> Result<bool, Error> {
+        if let Some(converted) = conversion_datatype_for_mode(ty, mode)?
+            && converted != *ty
+        {
+            return empty_payload_uses_unit_encoding(&converted, types, seen, mode);
+        }
+
         match ty {
             DataType::Struct(strct) => match transparent_payload(strct, mode)? {
                 TransparentPayload::Payload(ty) => {
@@ -3693,8 +3702,12 @@ fn substitute_generics(ty: &mut DataType, generics: &[(specta::datatype::Generic
                 *ty = concrete.clone();
             }
         }
-        DataType::Struct(strct) => substitute_field_generics(&mut strct.fields, generics),
+        DataType::Struct(strct) => {
+            substitute_container_attribute_generics(&mut strct.attributes, generics);
+            substitute_field_generics(&mut strct.fields, generics);
+        }
         DataType::Enum(enm) => {
+            substitute_container_attribute_generics(&mut enm.attributes, generics);
             for (_, variant) in &mut enm.variants {
                 substitute_field_generics(&mut variant.fields, generics);
             }
@@ -3724,6 +3737,23 @@ fn substitute_generics(ty: &mut DataType, generics: &[(specta::datatype::Generic
             }
         }
         DataType::Primitive(_) | DataType::Reference(Reference::Opaque(_)) => {}
+    }
+}
+
+fn substitute_container_attribute_generics(
+    attributes: &mut specta::datatype::Attributes,
+    generics: &[(specta::datatype::Generic, DataType)],
+) {
+    for key in [
+        CONTAINER_INTO_RESOLVED,
+        CONTAINER_FROM_RESOLVED,
+        CONTAINER_TRY_FROM_RESOLVED,
+    ] {
+        let Some(mut ty) = attributes.get_named_as::<DataType>(key).cloned() else {
+            continue;
+        };
+        substitute_generics(&mut ty, generics);
+        attributes.insert(key, ty);
     }
 }
 

--- a/specta-serde/src/lib.rs
+++ b/specta-serde/src/lib.rs
@@ -2984,12 +2984,12 @@ fn internal_tag_payload_compatibility(
             Ok(EnumRepr::Untagged) => {
                 let mut is_effectively_empty = true;
                 let mut rewritten = enm.clone();
-                let mut changed = false;
-                for ((_, variant), (_, rewritten_variant)) in
-                    enm.variants.iter().zip(&mut rewritten.variants)
-                {
+                filter_enum_variants_for_phase(&mut rewritten, mode)?;
+                let mut changed = rewritten.variants.len() != enm.variants.len();
+                for (_, rewritten_variant) in &mut rewritten.variants {
+                    let variant = rewritten_variant.clone();
                     let Some(variant_payload) = internal_tag_variant_payload_compatibility(
-                        variant,
+                        &variant,
                         original_types,
                         seen,
                         mode,

--- a/specta-serde/src/lib.rs
+++ b/specta-serde/src/lib.rs
@@ -2955,15 +2955,9 @@ fn internal_tag_payload_compatibility(
                 return Ok(Some(InternalTagPayloadCompatibility::merge_as_is()));
             }
 
-            let mut compatible =
+            let compatible =
                 internal_tag_payload_compatibility(&referenced_ty, original_types, seen, mode)?;
             seen.remove(&key);
-            if let Some(replacement) = compatible
-                .as_mut()
-                .and_then(|payload| payload.replacement.as_mut())
-            {
-                substitute_generics(replacement, named_reference_generics(reference));
-            }
             Ok(compatible)
         }
         DataType::Enum(enm)

--- a/specta-serde/src/lib.rs
+++ b/specta-serde/src/lib.rs
@@ -1838,7 +1838,7 @@ fn rewrite_enum_repr_for_phase(
         }
 
         let hidden_external_payload =
-            matches!(repr, EnumRepr::External) && variant_payload_is_hidden(&variant, mode)?;
+            matches!(repr, EnumRepr::External) && variant_has_hidden_wire_field(&variant, mode)?;
         if variant_attrs.as_ref().is_some_and(|attrs| attrs.untagged) {
             let mut transformed_variant = transform_untagged_variant(&variant)?;
             // Clear attributes like the other transformed variants below, so
@@ -2657,6 +2657,31 @@ fn variant_payload_is_hidden(variant: &Variant, mode: PhaseRewrite) -> Result<bo
     Ok(false)
 }
 
+/// Whether any variant field is hidden from Specta but remains present on
+/// serde's wire in this phase. Contextual internally tagged lowering must
+/// reject these fields because their datatype is unavailable.
+fn variant_has_hidden_wire_field(variant: &Variant, mode: PhaseRewrite) -> Result<bool, Error> {
+    fn fields_have_hidden_wire_field<'a>(
+        fields: impl IntoIterator<Item = &'a Field>,
+        mode: PhaseRewrite,
+    ) -> Result<bool, Error> {
+        for field in fields {
+            if field.ty.is_none() && !should_skip_field_for_mode(field, mode)? {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    match &variant.fields {
+        Fields::Unit => Ok(false),
+        Fields::Unnamed(unnamed) => fields_have_hidden_wire_field(&unnamed.fields, mode),
+        Fields::Named(named) => {
+            fields_have_hidden_wire_field(named.fields.iter().map(|(_, field)| field), mode)
+        }
+    }
+}
+
 /// Whether a collapsed newtype variant's sole field carries a *serde* skip
 /// for the given phase, as opposed to being hidden by `#[specta(skip)]` (or a
 /// hand-built `Field { ty: None, .. }`), which serde knows nothing about.
@@ -3363,6 +3388,9 @@ pub(crate) fn internal_tag_payload_requires_contextual_rewrite_for_mode(
                     {
                         continue;
                     }
+                    if variant_has_hidden_wire_field(variant, mode)? {
+                        return Ok(true);
+                    }
                     if attrs.as_ref().is_some_and(|attrs| attrs.other) {
                         return Ok(true);
                     }
@@ -3551,7 +3579,7 @@ fn external_enum_requires_contextual_rewrite(
         {
             return Ok(true);
         }
-        if variant_payload_is_hidden(variant, mode)? {
+        if variant_has_hidden_wire_field(variant, mode)? {
             return Ok(true);
         }
 
@@ -3630,7 +3658,7 @@ fn external_enum_tagged_payload_datatype(
                 clone_variant_with_unnamed_fields(&variant, vec![Field::new(payload)]).fields;
         }
 
-        if variant_payload_is_hidden(&variant, mode)? {
+        if variant_has_hidden_wire_field(&variant, mode)? {
             return Err(Error::invalid_internally_tagged_variant(
                 variant_name.clone(),
                 "a payload hidden only from Specta cannot be represented inside an internal tag",

--- a/specta-serde/src/lib.rs
+++ b/specta-serde/src/lib.rs
@@ -3511,28 +3511,19 @@ fn external_enum_tagged_payload_datatype(
             true,
         )?;
 
-        if let Fields::Named(fields) = &variant.fields {
-            if fields
-                .fields
-                .iter()
-                .any(|(_, field)| field_is_flattened(field))
-            {
-                return Err(Error::invalid_internally_tagged_variant(
-                    variant_name.clone(),
-                    "flattened fields in a contextual external enum payload are not supported",
-                ));
-            }
-            if mode == PhaseRewrite::Deserialize
-                && fields
-                    .fields
-                    .iter()
-                    .any(|(_, field)| field_has_aliases(field))
-            {
-                return Err(Error::invalid_internally_tagged_variant(
-                    variant_name.clone(),
-                    "field aliases in a contextual external enum payload are not supported",
-                ));
-            }
+        if let Some(aliases) = lower_field_aliases_for_phase(&mut variant.fields, mode)? {
+            variant.fields =
+                clone_variant_with_unnamed_fields(&variant, vec![Field::new(aliases)]).fields;
+        } else if matches!(
+            &variant.fields,
+            Fields::Named(fields) if fields.fields.iter().any(|(_, field)| field_is_flattened(field))
+        ) {
+            let mut payload = Struct::unit();
+            payload.fields = variant.fields.clone();
+            let payload = lower_flattened_struct(&mut payload)?
+                .expect("a named payload containing flatten must be lowered");
+            variant.fields =
+                clone_variant_with_unnamed_fields(&variant, vec![Field::new(payload)]).fields;
         }
 
         if variant_payload_is_hidden(&variant, mode)? {

--- a/specta-serde/src/lib.rs
+++ b/specta-serde/src/lib.rs
@@ -3527,6 +3527,10 @@ fn external_enum_tagged_payload_datatype(
 
         let rename_rule =
             enum_variant_field_rename_rule(&container_attrs, &variant, mode, variant_name)?;
+        let conditional_omission_applies = !matches!(
+            &variant.fields,
+            Fields::Unnamed(unnamed) if unnamed.fields.len() == 1
+        );
         rewrite_fields_for_phase(
             &mut variant.fields,
             mode,
@@ -3536,19 +3540,20 @@ fn external_enum_tagged_payload_datatype(
             rename_rule,
             false,
             true,
+            conditional_omission_applies,
         )?;
 
-        if let Some(aliases) = lower_field_aliases_for_phase(&mut variant.fields, mode)? {
-            variant.fields =
-                clone_variant_with_unnamed_fields(&variant, vec![Field::new(aliases)]).fields;
-        } else if matches!(
+        let lowered = if matches!(
             &variant.fields,
             Fields::Named(fields) if fields.fields.iter().any(|(_, field)| field_is_flattened(field))
         ) {
             let mut payload = Struct::unit();
-            payload.fields = variant.fields.clone();
-            let payload = lower_flattened_struct(&mut payload)?
-                .expect("a named payload containing flatten must be lowered");
+            std::mem::swap(&mut payload.fields, &mut variant.fields);
+            lower_flattened_struct(&mut payload, mode)?
+        } else {
+            lower_field_aliases_for_phase(&mut variant.fields, mode)?
+        };
+        if let Some(payload) = lowered {
             variant.fields =
                 clone_variant_with_unnamed_fields(&variant, vec![Field::new(payload)]).fields;
         }

--- a/specta-serde/src/lib.rs
+++ b/specta-serde/src/lib.rs
@@ -3048,7 +3048,10 @@ pub(crate) fn internal_tag_payload_requires_contextual_rewrite(
         Contextual,
     }
 
-    fn transparent_payload(strct: &Struct) -> Result<TransparentPayload<'_>, Error> {
+    fn transparent_payload(
+        strct: &Struct,
+        mode: PhaseRewrite,
+    ) -> Result<TransparentPayload<'_>, Error> {
         if !SerdeContainerAttrs::from_attributes(&strct.attributes)?
             .is_some_and(|attrs| attrs.transparent)
         {
@@ -3066,7 +3069,7 @@ pub(crate) fn internal_tag_payload_requires_contextual_rewrite(
         };
         let mut live = Vec::new();
         for field in fields {
-            if should_skip_field_for_mode(field, PhaseRewrite::Unified)? {
+            if should_skip_field_for_mode(field, mode)? {
                 continue;
             }
             let Some(ty) = &field.ty else {
@@ -3085,11 +3088,12 @@ pub(crate) fn internal_tag_payload_requires_contextual_rewrite(
         ty: &DataType,
         types: &Types,
         seen: &mut HashSet<Reference>,
+        mode: PhaseRewrite,
     ) -> Result<bool, Error> {
         match ty {
-            DataType::Struct(strct) => match transparent_payload(strct)? {
+            DataType::Struct(strct) => match transparent_payload(strct, mode)? {
                 TransparentPayload::Payload(ty) => {
-                    empty_payload_uses_unit_encoding(ty, types, seen)
+                    empty_payload_uses_unit_encoding(ty, types, seen, mode)
                 }
                 TransparentPayload::Contextual => Ok(true),
                 TransparentPayload::NotTransparent => match &strct.fields {
@@ -3097,7 +3101,7 @@ pub(crate) fn internal_tag_payload_requires_contextual_rewrite(
                     Fields::Named(_) => Ok(false),
                     Fields::Unnamed(unnamed) if unnamed.fields.len() == 1 => {
                         unnamed.fields[0].ty.as_ref().map_or(Ok(true), |ty| {
-                            empty_payload_uses_unit_encoding(ty, types, seen)
+                            empty_payload_uses_unit_encoding(ty, types, seen, mode)
                         })
                     }
                     Fields::Unnamed(_) => Ok(true),
@@ -3121,7 +3125,7 @@ pub(crate) fn internal_tag_payload_requires_contextual_rewrite(
                 let result = match referenced_ty {
                     Some(mut ty) => {
                         substitute_generics(&mut ty, named_reference_generics(reference));
-                        empty_payload_uses_unit_encoding(&ty, types, seen)
+                        empty_payload_uses_unit_encoding(&ty, types, seen, mode)
                     }
                     None => Ok(true),
                 };
@@ -3141,7 +3145,7 @@ pub(crate) fn internal_tag_payload_requires_contextual_rewrite(
                             else {
                                 return Ok(true);
                             };
-                            if empty_payload_uses_unit_encoding(&payload, types, seen)? {
+                            if empty_payload_uses_unit_encoding(&payload, types, seen, mode)? {
                                 return Ok(true);
                             }
                         }
@@ -3151,7 +3155,7 @@ pub(crate) fn internal_tag_payload_requires_contextual_rewrite(
             }
             DataType::Intersection(parts) => {
                 for part in parts {
-                    if empty_payload_uses_unit_encoding(part, types, seen)? {
+                    if empty_payload_uses_unit_encoding(part, types, seen, mode)? {
                         return Ok(true);
                     }
                 }
@@ -3167,23 +3171,28 @@ pub(crate) fn internal_tag_payload_requires_contextual_rewrite(
         }
     }
 
-    fn inner(ty: &DataType, types: &Types, seen: &mut HashSet<Reference>) -> Result<bool, Error> {
-        if let Some(converted) = conversion_datatype_for_mode(ty, PhaseRewrite::Unified)?
+    fn inner(
+        ty: &DataType,
+        types: &Types,
+        seen: &mut HashSet<Reference>,
+        mode: PhaseRewrite,
+    ) -> Result<bool, Error> {
+        if let Some(converted) = conversion_datatype_for_mode(ty, mode)?
             && converted != *ty
         {
-            return inner(&converted, types, seen);
+            return inner(&converted, types, seen, mode);
         }
 
         match ty {
-            DataType::Struct(strct) => match transparent_payload(strct)? {
-                TransparentPayload::Payload(ty) => inner(ty, types, seen),
+            DataType::Struct(strct) => match transparent_payload(strct, mode)? {
+                TransparentPayload::Payload(ty) => inner(ty, types, seen, mode),
                 TransparentPayload::Contextual => Ok(true),
                 TransparentPayload::NotTransparent => match &strct.fields {
                     Fields::Unnamed(unnamed) if unnamed.fields.len() == 1 => {
                         let field = &unnamed.fields[0];
                         match &field.ty {
-                            Some(ty) => inner(ty, types, seen),
-                            None => Ok(!should_skip_field_for_mode(field, PhaseRewrite::Unified)?),
+                            Some(ty) => inner(ty, types, seen, mode),
+                            None => Ok(!should_skip_field_for_mode(field, mode)?),
                         }
                     }
                     Fields::Unit => Ok(true),
@@ -3208,12 +3217,69 @@ pub(crate) fn internal_tag_payload_requires_contextual_rewrite(
                 let result = match referenced_ty {
                     Some(mut ty) => {
                         substitute_generics(&mut ty, named_reference_generics(reference));
-                        inner(&ty, types, seen)
+                        inner(&ty, types, seen, mode)
                     }
                     None => Ok(false),
                 };
                 seen.remove(&key);
                 result
+            }
+            DataType::Enum(enm)
+                if matches!(EnumRepr::from_attrs(&enm.attributes)?, EnumRepr::Untagged) =>
+            {
+                for (_, variant) in &enm.variants {
+                    if variant.skip {
+                        continue;
+                    }
+                    let attrs = SerdeVariantAttrs::from_attributes(&variant.attributes)?;
+                    if attrs
+                        .as_ref()
+                        .is_some_and(|attrs| variant_is_skipped_for_mode(attrs, mode))
+                    {
+                        continue;
+                    }
+
+                    let Some(payload) = internal_tag_variant_payload_compatibility(
+                        variant,
+                        types,
+                        &mut HashSet::new(),
+                        mode,
+                    )?
+                    else {
+                        return Ok(true);
+                    };
+                    if payload.replacement.is_some() {
+                        return Ok(true);
+                    }
+                    if !payload.is_effectively_empty {
+                        continue;
+                    }
+
+                    match &variant.fields {
+                        Fields::Unit => return Ok(true),
+                        Fields::Named(_) => {}
+                        Fields::Unnamed(unnamed) => {
+                            let [field] = unnamed.fields.as_slice() else {
+                                return Ok(true);
+                            };
+                            if should_skip_field_for_mode(field, mode)? {
+                                return Ok(true);
+                            }
+                            let Some(ty) = &field.ty else {
+                                return Ok(true);
+                            };
+                            if empty_payload_uses_unit_encoding(
+                                ty,
+                                types,
+                                &mut HashSet::new(),
+                                mode,
+                            )? {
+                                return Ok(true);
+                            }
+                        }
+                    }
+                }
+                Ok(false)
             }
             DataType::Enum(enm)
                 if matches!(EnumRepr::from_attrs(&enm.attributes)?, EnumRepr::External) =>
@@ -3223,9 +3289,10 @@ pub(crate) fn internal_tag_payload_requires_contextual_rewrite(
                         continue;
                     }
                     let attrs = SerdeVariantAttrs::from_attributes(&variant.attributes)?;
-                    if attrs.as_ref().is_some_and(|attrs| {
-                        variant_is_skipped_for_mode(attrs, PhaseRewrite::Unified)
-                    }) {
+                    if attrs
+                        .as_ref()
+                        .is_some_and(|attrs| variant_is_skipped_for_mode(attrs, mode))
+                    {
                         continue;
                     }
                     if attrs.as_ref().is_some_and(|attrs| attrs.other) {
@@ -3236,7 +3303,7 @@ pub(crate) fn internal_tag_payload_requires_contextual_rewrite(
                             variant,
                             types,
                             &mut HashSet::new(),
-                            PhaseRewrite::Unified,
+                            mode,
                         )?;
                         let requires_rewrite = match compatibility {
                             None => true,
@@ -3245,16 +3312,21 @@ pub(crate) fn internal_tag_payload_requires_contextual_rewrite(
                                 match &variant.fields {
                                     Fields::Unit => true,
                                     Fields::Named(_) => false,
-                                    Fields::Unnamed(_) => {
-                                        let Some(ty) = variant_payload_field(variant)
-                                            .and_then(|field| field.ty)
-                                        else {
+                                    Fields::Unnamed(unnamed) => {
+                                        let [field] = unnamed.fields.as_slice() else {
+                                            return Ok(true);
+                                        };
+                                        if should_skip_field_for_mode(field, mode)? {
+                                            return Ok(true);
+                                        }
+                                        let Some(ty) = &field.ty else {
                                             return Ok(true);
                                         };
                                         empty_payload_uses_unit_encoding(
-                                            &ty,
+                                            ty,
                                             types,
                                             &mut HashSet::new(),
+                                            mode,
                                         )?
                                     }
                                 }
@@ -3271,8 +3343,7 @@ pub(crate) fn internal_tag_payload_requires_contextual_rewrite(
                         Fields::Unit => return Ok(true),
                         Fields::Unnamed(unnamed) => {
                             if let [field] = unnamed.fields.as_slice()
-                                && (field.ty.is_none()
-                                    || should_skip_field_for_mode(field, PhaseRewrite::Unified)?)
+                                && (field.ty.is_none() || should_skip_field_for_mode(field, mode)?)
                             {
                                 return Ok(true);
                             }
@@ -3284,7 +3355,7 @@ pub(crate) fn internal_tag_payload_requires_contextual_rewrite(
             }
             DataType::Intersection(parts) => {
                 for part in parts {
-                    if inner(part, types, seen)? {
+                    if inner(part, types, seen, mode)? {
                         return Ok(true);
                     }
                 }
@@ -3301,7 +3372,10 @@ pub(crate) fn internal_tag_payload_requires_contextual_rewrite(
         }
     }
 
-    inner(ty, types, &mut HashSet::new())
+    if inner(ty, types, &mut HashSet::new(), PhaseRewrite::Serialize)? {
+        return Ok(true);
+    }
+    inner(ty, types, &mut HashSet::new(), PhaseRewrite::Deserialize)
 }
 
 fn contextualize_rewritten_external_units(
@@ -3632,13 +3706,13 @@ fn internal_tag_variant_payload_compatibility(
                 return Ok(None);
             }
 
-            unnamed
-                .fields
-                .iter()
-                .find_map(|field| field.ty.as_ref())
-                .map_or(Ok(None), |ty| {
-                    internal_tag_payload_compatibility(ty, original_types, seen, mode)
-                })
+            let field = &unnamed.fields[0];
+            if should_skip_field_for_mode(field, mode)? {
+                return Ok(Some(InternalTagPayloadCompatibility::empty()));
+            }
+            field.ty.as_ref().map_or(Ok(None), |ty| {
+                internal_tag_payload_compatibility(ty, original_types, seen, mode)
+            })
         }
     }
 }

--- a/specta-serde/src/lib.rs
+++ b/specta-serde/src/lib.rs
@@ -2499,6 +2499,13 @@ fn transform_internal_variant(
             fields.extend(named.fields.iter().cloned());
         }
         Fields::Unnamed(unnamed) => {
+            if variant_payload_is_hidden(variant, mode)? {
+                return Err(Error::invalid_internally_tagged_variant(
+                    serialized_name,
+                    "a payload hidden only from Specta cannot be represented inside an internal tag",
+                ));
+            }
+
             let live_field_count = unnamed_live_field_count(unnamed);
 
             if live_field_count == 0 {
@@ -2520,10 +2527,11 @@ fn transform_internal_variant(
                 .expect("checked above")
                 .clone();
             let payload_ty = payload_field.ty.clone().expect("checked above");
-            let Some(payload_is_effectively_empty) = internal_tag_payload_compatibility(
+            let Some(payload) = internal_tag_payload_compatibility(
                 &payload_ty,
                 original_types,
                 &mut HashSet::new(),
+                mode,
             )?
             else {
                 return Err(Error::invalid_internally_tagged_variant(
@@ -2532,12 +2540,12 @@ fn transform_internal_variant(
                 ));
             };
 
-            if !payload_is_effectively_empty {
+            if !payload.is_effectively_empty {
                 return Ok(clone_variant_with_unnamed_fields(
                     variant,
                     vec![Field::new(DataType::Intersection(vec![
                         named_fields_datatype(fields),
-                        payload_ty,
+                        payload.replacement.unwrap_or(payload_ty),
                     ]))],
                 ));
             }
@@ -2770,19 +2778,81 @@ fn clone_variant_with_unnamed_fields(original: &Variant, fields: Vec<Field>) -> 
     transformed
 }
 
+struct InternalTagPayloadCompatibility {
+    is_effectively_empty: bool,
+    replacement: Option<DataType>,
+}
+
+impl InternalTagPayloadCompatibility {
+    fn empty() -> Self {
+        Self {
+            is_effectively_empty: true,
+            replacement: None,
+        }
+    }
+
+    fn merge_as_is() -> Self {
+        Self {
+            is_effectively_empty: false,
+            replacement: None,
+        }
+    }
+}
+
 fn internal_tag_payload_compatibility(
     ty: &DataType,
     original_types: &Types,
-    seen: &mut HashSet<TypeIdentity>,
-) -> Result<Option<bool>, Error> {
+    seen: &mut HashSet<Reference>,
+    mode: PhaseRewrite,
+) -> Result<Option<InternalTagPayloadCompatibility>, Error> {
+    if let Some(converted) = conversion_datatype_for_mode(ty, mode)?
+        && converted != *ty
+    {
+        let Some(mut compatibility) =
+            internal_tag_payload_compatibility(&converted, original_types, seen, mode)?
+        else {
+            return Ok(None);
+        };
+        if !compatibility.is_effectively_empty && compatibility.replacement.is_none() {
+            compatibility.replacement = Some(converted);
+        }
+        return Ok(Some(compatibility));
+    }
+
     match ty {
-        DataType::Map(_) => Ok(Some(false)),
+        DataType::Map(_) | DataType::Generic(_) => {
+            Ok(Some(InternalTagPayloadCompatibility::merge_as_is()))
+        }
         DataType::Struct(strct) => {
             if SerdeContainerAttrs::from_attributes(&strct.attributes)?
                 .is_some_and(|attrs| attrs.transparent)
             {
+                let has_hidden_wire_data =
+                    match &strct.fields {
+                        Fields::Unit => Ok(false),
+                        Fields::Unnamed(unnamed) => unnamed.fields.iter().try_fold(
+                            false,
+                            |hidden, field| -> Result<_, Error> {
+                                Ok(hidden
+                                    || (field.ty.is_none()
+                                        && !should_skip_field_for_mode(field, mode)?))
+                            },
+                        ),
+                        Fields::Named(named) => named.fields.iter().try_fold(
+                            false,
+                            |hidden, (_, field)| -> Result<_, Error> {
+                                Ok(hidden
+                                    || (field.ty.is_none()
+                                        && !should_skip_field_for_mode(field, mode)?))
+                            },
+                        ),
+                    }?;
+                if has_hidden_wire_data {
+                    return Ok(None);
+                }
+
                 let payload_fields = match &strct.fields {
-                    Fields::Unit => return Ok(Some(true)),
+                    Fields::Unit => return Ok(Some(InternalTagPayloadCompatibility::empty())),
                     Fields::Unnamed(unnamed) => unnamed
                         .fields
                         .iter()
@@ -2797,104 +2867,766 @@ fn internal_tag_payload_compatibility(
 
                 let [inner_ty] = payload_fields.as_slice() else {
                     if payload_fields.is_empty() {
-                        return Ok(Some(true));
+                        return Ok(Some(InternalTagPayloadCompatibility::empty()));
                     }
 
                     return Ok(None);
                 };
 
-                return internal_tag_payload_compatibility(inner_ty, original_types, seen);
+                return internal_tag_payload_compatibility(inner_ty, original_types, seen, mode);
             }
 
-            Ok(match &strct.fields {
-                Fields::Named(named) => Some(
-                    named
-                        .fields
-                        .iter()
-                        .all(|(_, field)| field.ty.as_ref().is_none()),
-                ),
-                Fields::Unit | Fields::Unnamed(_) => None,
-            })
+            match &strct.fields {
+                Fields::Unit => Ok(Some(InternalTagPayloadCompatibility::empty())),
+                Fields::Named(named) => {
+                    let mut is_effectively_empty = true;
+                    for (_, field) in &named.fields {
+                        if field.ty.is_some() {
+                            is_effectively_empty = false;
+                        } else if !should_skip_field_for_mode(field, mode)? {
+                            return Ok(None);
+                        }
+                    }
+                    Ok(Some(InternalTagPayloadCompatibility {
+                        is_effectively_empty,
+                        replacement: None,
+                    }))
+                }
+                // Serde's newtype structs delegate their payload back into
+                // `TaggedSerializer`. Empty and multi-field tuple structs use
+                // the unsupported tuple-struct path instead.
+                Fields::Unnamed(unnamed) if unnamed.fields.len() == 1 => {
+                    let Some(inner_ty) = unnamed.fields[0].ty.as_ref() else {
+                        return if should_skip_field_for_mode(&unnamed.fields[0], mode)? {
+                            Ok(Some(InternalTagPayloadCompatibility::empty()))
+                        } else {
+                            Ok(None)
+                        };
+                    };
+                    internal_tag_payload_compatibility(inner_ty, original_types, seen, mode)
+                }
+                Fields::Unnamed(_) => Ok(None),
+            }
         }
-        DataType::Tuple(tuple) => Ok(tuple.elements.is_empty().then_some(true)),
+        DataType::Tuple(tuple) => Ok(tuple
+            .elements
+            .is_empty()
+            .then(InternalTagPayloadCompatibility::empty)),
         DataType::Intersection(types) => {
             let mut is_effectively_empty = true;
+            let mut replacements = Vec::with_capacity(types.len());
+            let mut was_rewritten = false;
 
             for ty in types {
-                let Some(part_empty) =
-                    internal_tag_payload_compatibility(ty, original_types, seen)?
+                let Some(part) =
+                    internal_tag_payload_compatibility(ty, original_types, seen, mode)?
                 else {
                     return Ok(None);
                 };
 
-                is_effectively_empty &= part_empty;
+                is_effectively_empty &= part.is_effectively_empty;
+                was_rewritten |= part.replacement.is_some();
+                replacements.push(part.replacement.unwrap_or_else(|| ty.clone()));
             }
 
-            Ok(Some(is_effectively_empty))
+            Ok(Some(InternalTagPayloadCompatibility {
+                is_effectively_empty,
+                replacement: was_rewritten.then_some(DataType::Intersection(replacements)),
+            }))
         }
         DataType::Reference(Reference::Named(reference)) => {
-            if let NamedReferenceType::Inline { dt, .. } = &reference.inner {
-                return internal_tag_payload_compatibility(dt, original_types, seen);
-            }
-
-            let Some(referenced) = original_types.get(reference) else {
-                return Ok(None);
+            let referenced_ty = match &reference.inner {
+                NamedReferenceType::Inline { dt, .. } => (**dt).clone(),
+                NamedReferenceType::Reference { .. } | NamedReferenceType::Recursive(_) => {
+                    let Some(ty) = original_types
+                        .get(reference)
+                        .and_then(|referenced| referenced.ty.as_ref())
+                    else {
+                        return Ok(None);
+                    };
+                    ty.clone()
+                }
             };
-            let Some(referenced_ty) = referenced.ty.as_ref() else {
-                return Ok(None);
-            };
+            let mut referenced_ty = referenced_ty;
+            substitute_generics(&mut referenced_ty, named_reference_generics(reference));
 
-            let key = TypeIdentity::from_ndt(referenced);
+            let key = Reference::Named(reference.clone());
             if !seen.insert(key.clone()) {
-                return Ok(Some(false));
+                return Ok(Some(InternalTagPayloadCompatibility::merge_as_is()));
             }
 
-            let compatible =
-                internal_tag_payload_compatibility(referenced_ty, original_types, seen);
+            let mut compatible =
+                internal_tag_payload_compatibility(&referenced_ty, original_types, seen, mode)?;
             seen.remove(&key);
-            compatible
+            if let Some(replacement) = compatible
+                .as_mut()
+                .and_then(|payload| payload.replacement.as_mut())
+            {
+                substitute_generics(replacement, named_reference_generics(reference));
+            }
+            Ok(compatible)
+        }
+        DataType::Enum(enm)
+            if enm.attributes.contains_key(ENUM_REPR_REWRITTEN_MARKER)
+                && !matches!(
+                    EnumRepr::from_attrs(&enm.attributes),
+                    Ok(EnumRepr::Untagged)
+                ) =>
+        {
+            Ok(Some(contextualize_rewritten_external_units(enm)?))
         }
         DataType::Enum(enm) => match EnumRepr::from_attrs(&enm.attributes) {
             Ok(EnumRepr::Untagged) => {
                 let mut is_effectively_empty = true;
-                for (_, variant) in &enm.variants {
-                    let Some(variant_empty) =
-                        internal_tag_variant_payload_compatibility(variant, original_types, seen)?
+                let mut rewritten = enm.clone();
+                let mut changed = false;
+                for ((_, variant), (_, rewritten_variant)) in
+                    enm.variants.iter().zip(&mut rewritten.variants)
+                {
+                    let Some(variant_payload) = internal_tag_variant_payload_compatibility(
+                        variant,
+                        original_types,
+                        seen,
+                        mode,
+                    )?
                     else {
                         return Ok(None);
                     };
 
-                    is_effectively_empty &= variant_empty;
+                    is_effectively_empty &= variant_payload.is_effectively_empty;
+                    let replacement = variant_payload.replacement.or_else(|| {
+                        variant_payload
+                            .is_effectively_empty
+                            .then(|| named_fields_datatype(Vec::new()))
+                    });
+                    if let Some(replacement) = replacement {
+                        *rewritten_variant = clone_variant_with_unnamed_fields(
+                            rewritten_variant,
+                            vec![Field::new(replacement)],
+                        );
+                        changed = true;
+                    }
                 }
 
-                Ok(Some(is_effectively_empty))
+                Ok(Some(InternalTagPayloadCompatibility {
+                    is_effectively_empty,
+                    replacement: changed.then_some(DataType::Enum(rewritten)),
+                }))
             }
-            Ok(EnumRepr::External | EnumRepr::Internal { .. } | EnumRepr::Adjacent { .. }) => {
-                Ok(Some(false))
+            Ok(EnumRepr::External) => {
+                if !external_enum_requires_contextual_rewrite(enm, mode)? {
+                    return Ok(Some(InternalTagPayloadCompatibility::merge_as_is()));
+                }
+                Ok(Some(InternalTagPayloadCompatibility {
+                    is_effectively_empty: false,
+                    replacement: Some(external_enum_tagged_payload_datatype(
+                        enm,
+                        original_types,
+                        mode,
+                    )?),
+                }))
+            }
+            Ok(EnumRepr::Internal { .. } | EnumRepr::Adjacent { .. }) => {
+                Ok(Some(InternalTagPayloadCompatibility::merge_as_is()))
             }
             Err(_) => Ok(None),
         },
         DataType::Primitive(_)
         | DataType::List(_)
         | DataType::Nullable(_)
-        | DataType::Reference(Reference::Opaque(_))
-        | DataType::Generic(_) => Ok(None),
+        | DataType::Reference(Reference::Opaque(_)) => Ok(None),
+    }
+}
+
+pub(crate) fn internal_tag_payload_requires_contextual_rewrite(
+    ty: &DataType,
+    types: &Types,
+) -> Result<bool, Error> {
+    enum TransparentPayload<'a> {
+        NotTransparent,
+        Payload(&'a DataType),
+        Contextual,
+    }
+
+    fn transparent_payload(strct: &Struct) -> Result<TransparentPayload<'_>, Error> {
+        if !SerdeContainerAttrs::from_attributes(&strct.attributes)?
+            .is_some_and(|attrs| attrs.transparent)
+        {
+            return Ok(TransparentPayload::NotTransparent);
+        }
+
+        let fields = match &strct.fields {
+            Fields::Unit => Vec::new(),
+            Fields::Unnamed(unnamed) => unnamed.fields.iter().collect::<Vec<_>>(),
+            Fields::Named(named) => named
+                .fields
+                .iter()
+                .map(|(_, field)| field)
+                .collect::<Vec<_>>(),
+        };
+        let mut live = Vec::new();
+        for field in fields {
+            if should_skip_field_for_mode(field, PhaseRewrite::Unified)? {
+                continue;
+            }
+            let Some(ty) = &field.ty else {
+                return Ok(TransparentPayload::Contextual);
+            };
+            live.push(ty);
+        }
+
+        Ok(match live.as_slice() {
+            [ty] => TransparentPayload::Payload(ty),
+            _ => TransparentPayload::Contextual,
+        })
+    }
+
+    fn empty_payload_uses_unit_encoding(
+        ty: &DataType,
+        types: &Types,
+        seen: &mut HashSet<Reference>,
+    ) -> Result<bool, Error> {
+        match ty {
+            DataType::Struct(strct) => match transparent_payload(strct)? {
+                TransparentPayload::Payload(ty) => {
+                    empty_payload_uses_unit_encoding(ty, types, seen)
+                }
+                TransparentPayload::Contextual => Ok(true),
+                TransparentPayload::NotTransparent => match &strct.fields {
+                    Fields::Unit => Ok(true),
+                    Fields::Named(_) => Ok(false),
+                    Fields::Unnamed(unnamed) if unnamed.fields.len() == 1 => {
+                        unnamed.fields[0].ty.as_ref().map_or(Ok(true), |ty| {
+                            empty_payload_uses_unit_encoding(ty, types, seen)
+                        })
+                    }
+                    Fields::Unnamed(_) => Ok(true),
+                },
+            },
+            DataType::Tuple(tuple) => Ok(tuple.elements.is_empty()),
+            DataType::Reference(Reference::Named(reference)) => {
+                let key = Reference::Named(reference.clone());
+                if !seen.insert(key.clone()) {
+                    return Ok(false);
+                }
+                let referenced_ty = match &reference.inner {
+                    NamedReferenceType::Inline { dt, .. } => Some((**dt).clone()),
+                    NamedReferenceType::Reference { .. } | NamedReferenceType::Recursive(_) => {
+                        types
+                            .get(reference)
+                            .and_then(|ndt| ndt.ty.as_ref())
+                            .cloned()
+                    }
+                };
+                let result = match referenced_ty {
+                    Some(mut ty) => {
+                        substitute_generics(&mut ty, named_reference_generics(reference));
+                        empty_payload_uses_unit_encoding(&ty, types, seen)
+                    }
+                    None => Ok(true),
+                };
+                seen.remove(&key);
+                result
+            }
+            DataType::Enum(enm)
+                if matches!(EnumRepr::from_attrs(&enm.attributes)?, EnumRepr::Untagged) =>
+            {
+                for (_, variant) in &enm.variants {
+                    match &variant.fields {
+                        Fields::Unit => return Ok(true),
+                        Fields::Named(_) => {}
+                        Fields::Unnamed(_) => {
+                            let Some(payload) =
+                                variant_payload_field(variant).and_then(|field| field.ty)
+                            else {
+                                return Ok(true);
+                            };
+                            if empty_payload_uses_unit_encoding(&payload, types, seen)? {
+                                return Ok(true);
+                            }
+                        }
+                    }
+                }
+                Ok(false)
+            }
+            DataType::Intersection(parts) => {
+                for part in parts {
+                    if empty_payload_uses_unit_encoding(part, types, seen)? {
+                        return Ok(true);
+                    }
+                }
+                Ok(false)
+            }
+            DataType::Map(_) => Ok(false),
+            DataType::Enum(_)
+            | DataType::Primitive(_)
+            | DataType::List(_)
+            | DataType::Nullable(_)
+            | DataType::Generic(_)
+            | DataType::Reference(Reference::Opaque(_)) => Ok(true),
+        }
+    }
+
+    fn inner(ty: &DataType, types: &Types, seen: &mut HashSet<Reference>) -> Result<bool, Error> {
+        if let Some(converted) = conversion_datatype_for_mode(ty, PhaseRewrite::Unified)?
+            && converted != *ty
+        {
+            return inner(&converted, types, seen);
+        }
+
+        match ty {
+            DataType::Struct(strct) => match transparent_payload(strct)? {
+                TransparentPayload::Payload(ty) => inner(ty, types, seen),
+                TransparentPayload::Contextual => Ok(true),
+                TransparentPayload::NotTransparent => match &strct.fields {
+                    Fields::Unnamed(unnamed) if unnamed.fields.len() == 1 => {
+                        let field = &unnamed.fields[0];
+                        match &field.ty {
+                            Some(ty) => inner(ty, types, seen),
+                            None => Ok(!should_skip_field_for_mode(field, PhaseRewrite::Unified)?),
+                        }
+                    }
+                    Fields::Unit => Ok(true),
+                    Fields::Named(_) | Fields::Unnamed(_) => Ok(false),
+                },
+            },
+            DataType::Reference(Reference::Named(reference)) => {
+                let key = Reference::Named(reference.clone());
+                if !seen.insert(key.clone()) {
+                    return Ok(false);
+                }
+
+                let referenced_ty = match &reference.inner {
+                    NamedReferenceType::Inline { dt, .. } => Some((**dt).clone()),
+                    NamedReferenceType::Reference { .. } | NamedReferenceType::Recursive(_) => {
+                        types
+                            .get(reference)
+                            .and_then(|ndt| ndt.ty.as_ref())
+                            .cloned()
+                    }
+                };
+                let result = match referenced_ty {
+                    Some(mut ty) => {
+                        substitute_generics(&mut ty, named_reference_generics(reference));
+                        inner(&ty, types, seen)
+                    }
+                    None => Ok(false),
+                };
+                seen.remove(&key);
+                result
+            }
+            DataType::Enum(enm)
+                if matches!(EnumRepr::from_attrs(&enm.attributes)?, EnumRepr::External) =>
+            {
+                for (_, variant) in &enm.variants {
+                    if variant.skip {
+                        continue;
+                    }
+                    let attrs = SerdeVariantAttrs::from_attributes(&variant.attributes)?;
+                    if attrs.as_ref().is_some_and(|attrs| {
+                        variant_is_skipped_for_mode(attrs, PhaseRewrite::Unified)
+                    }) {
+                        continue;
+                    }
+                    if attrs.as_ref().is_some_and(|attrs| attrs.other) {
+                        return Ok(true);
+                    }
+                    if attrs.as_ref().is_some_and(|attrs| attrs.untagged) {
+                        let compatibility = internal_tag_variant_payload_compatibility(
+                            variant,
+                            types,
+                            &mut HashSet::new(),
+                            PhaseRewrite::Unified,
+                        )?;
+                        let requires_rewrite = match compatibility {
+                            None => true,
+                            Some(payload) if payload.replacement.is_some() => true,
+                            Some(payload) if payload.is_effectively_empty => {
+                                match &variant.fields {
+                                    Fields::Unit => true,
+                                    Fields::Named(_) => false,
+                                    Fields::Unnamed(_) => {
+                                        let Some(ty) = variant_payload_field(variant)
+                                            .and_then(|field| field.ty)
+                                        else {
+                                            return Ok(true);
+                                        };
+                                        empty_payload_uses_unit_encoding(
+                                            &ty,
+                                            types,
+                                            &mut HashSet::new(),
+                                        )?
+                                    }
+                                }
+                            }
+                            Some(_) => false,
+                        };
+                        if requires_rewrite {
+                            return Ok(true);
+                        }
+                        continue;
+                    }
+
+                    match &variant.fields {
+                        Fields::Unit => return Ok(true),
+                        Fields::Unnamed(unnamed) => {
+                            if let [field] = unnamed.fields.as_slice()
+                                && (field.ty.is_none()
+                                    || should_skip_field_for_mode(field, PhaseRewrite::Unified)?)
+                            {
+                                return Ok(true);
+                            }
+                        }
+                        Fields::Named(_) => {}
+                    }
+                }
+                Ok(false)
+            }
+            DataType::Intersection(parts) => {
+                for part in parts {
+                    if inner(part, types, seen)? {
+                        return Ok(true);
+                    }
+                }
+                Ok(false)
+            }
+            DataType::Tuple(tuple) => Ok(tuple.elements.is_empty()),
+            DataType::Enum(_)
+            | DataType::Map(_)
+            | DataType::List(_)
+            | DataType::Nullable(_)
+            | DataType::Primitive(_)
+            | DataType::Generic(_)
+            | DataType::Reference(Reference::Opaque(_)) => Ok(false),
+        }
+    }
+
+    inner(ty, types, &mut HashSet::new())
+}
+
+fn contextualize_rewritten_external_units(
+    enm: &Enum,
+) -> Result<InternalTagPayloadCompatibility, Error> {
+    let mut rewritten = enm.clone();
+    let mut changed = false;
+
+    for (name, variant) in &mut rewritten.variants {
+        let Fields::Unnamed(fields) = &variant.fields else {
+            continue;
+        };
+        let [field] = fields.fields.as_slice() else {
+            continue;
+        };
+        let Some(ty) = field.ty.as_ref() else {
+            continue;
+        };
+        if matches!(ty, DataType::Primitive(Primitive::str)) {
+            return Err(Error::invalid_internally_tagged_variant(
+                name.clone(),
+                "an external enum payload with `#[serde(other)]` cannot be represented generically inside an internal tag",
+            ));
+        }
+        if matches!(ty, DataType::Tuple(tuple) if tuple.elements.is_empty()) {
+            *variant = clone_variant_with_unnamed_fields(
+                variant,
+                vec![Field::new(named_fields_datatype(Vec::new()))],
+            );
+            variant.attributes = Default::default();
+            changed = true;
+            continue;
+        }
+        if !is_generated_string_literal_datatype(ty) {
+            continue;
+        }
+
+        *variant = clone_variant_with_named_fields(
+            variant,
+            vec![(
+                name.clone(),
+                Field::new(DataType::Tuple(Tuple::new(vec![]))),
+            )],
+        );
+        variant.attributes = Default::default();
+        changed = true;
+    }
+
+    if changed {
+        Ok(InternalTagPayloadCompatibility {
+            is_effectively_empty: false,
+            replacement: Some(DataType::Enum(rewritten)),
+        })
+    } else {
+        Ok(InternalTagPayloadCompatibility::merge_as_is())
+    }
+}
+
+fn external_enum_requires_contextual_rewrite(
+    enm: &Enum,
+    mode: PhaseRewrite,
+) -> Result<bool, Error> {
+    for (_, variant) in &enm.variants {
+        if variant.skip {
+            continue;
+        }
+        let attrs = SerdeVariantAttrs::from_attributes(&variant.attributes)?;
+        if attrs
+            .as_ref()
+            .is_some_and(|attrs| variant_is_skipped_for_mode(attrs, mode))
+        {
+            continue;
+        }
+        if attrs
+            .as_ref()
+            .is_some_and(|attrs| attrs.other || attrs.untagged)
+        {
+            return Ok(true);
+        }
+
+        match &variant.fields {
+            Fields::Unit => return Ok(true),
+            Fields::Unnamed(unnamed) => {
+                if let [field] = unnamed.fields.as_slice()
+                    && (field.ty.is_none() || should_skip_field_for_mode(field, mode)?)
+                {
+                    return Ok(true);
+                }
+            }
+            Fields::Named(_) => {}
+        }
+    }
+
+    Ok(false)
+}
+
+// An externally tagged enum normally renders a unit variant as a string, but
+// serde's `TaggedSerializer` always writes the inner discriminant as a map
+// entry. Build the contextual representation used only inside the outer
+// internally tagged newtype variant.
+fn external_enum_tagged_payload_datatype(
+    enm: &Enum,
+    original_types: &Types,
+    mode: PhaseRewrite,
+) -> Result<DataType, Error> {
+    let container_attrs = SerdeContainerAttrs::from_attributes(&enm.attributes)?;
+    let mut transformed = Enum::default();
+
+    for (variant_name, original_variant) in &enm.variants {
+        let mut variant = original_variant.clone();
+        if variant.skip {
+            continue;
+        }
+
+        let variant_attrs = SerdeVariantAttrs::from_attributes(&variant.attributes)?;
+        if variant_attrs
+            .as_ref()
+            .is_some_and(|attrs| variant_is_skipped_for_mode(attrs, mode))
+        {
+            continue;
+        }
+
+        let rename_rule =
+            enum_variant_field_rename_rule(&container_attrs, &variant, mode, variant_name)?;
+        rewrite_fields_for_phase(
+            &mut variant.fields,
+            mode,
+            original_types,
+            &HashMap::new(),
+            &HashSet::new(),
+            rename_rule,
+            false,
+            true,
+        )?;
+
+        if let Fields::Named(fields) = &variant.fields {
+            if fields
+                .fields
+                .iter()
+                .any(|(_, field)| field_is_flattened(field))
+            {
+                return Err(Error::invalid_internally_tagged_variant(
+                    variant_name.clone(),
+                    "flattened fields in a contextual external enum payload are not supported",
+                ));
+            }
+            if mode == PhaseRewrite::Deserialize
+                && fields
+                    .fields
+                    .iter()
+                    .any(|(_, field)| field_has_aliases(field))
+            {
+                return Err(Error::invalid_internally_tagged_variant(
+                    variant_name.clone(),
+                    "field aliases in a contextual external enum payload are not supported",
+                ));
+            }
+        }
+
+        if variant_payload_is_hidden(&variant, mode)? {
+            return Err(Error::invalid_internally_tagged_variant(
+                variant_name.clone(),
+                "a payload hidden only from Specta cannot be represented inside an internal tag",
+            ));
+        }
+
+        if variant_attrs.as_ref().is_some_and(|attrs| attrs.untagged) {
+            let payload = match &variant.fields {
+                Fields::Unit => named_fields_datatype(Vec::new()),
+                _ => {
+                    let payload = variant_payload_field(&variant)
+                        .ok_or_else(|| {
+                            Error::invalid_external_tagged_variant(variant_name.clone())
+                        })?
+                        .ty
+                        .expect("variant payload fields always have a datatype");
+                    let Some(compatibility) = internal_tag_payload_compatibility(
+                        &payload,
+                        original_types,
+                        &mut HashSet::new(),
+                        mode,
+                    )?
+                    else {
+                        return Err(Error::invalid_internally_tagged_variant(
+                            variant_name.clone(),
+                            "untagged payload cannot be merged with a tag",
+                        ));
+                    };
+
+                    if compatibility.is_effectively_empty {
+                        named_fields_datatype(Vec::new())
+                    } else {
+                        compatibility.replacement.unwrap_or(payload)
+                    }
+                }
+            };
+            let mut transformed_variant =
+                clone_variant_with_unnamed_fields(&variant, vec![Field::new(payload)]);
+            transformed_variant.attributes = Default::default();
+            transformed
+                .variants
+                .push((variant_name.clone(), transformed_variant));
+            continue;
+        }
+
+        let serialized_name =
+            serialized_variant_name(variant_name, &variant, &container_attrs, mode)?;
+        let aliases = variant_attrs
+            .as_ref()
+            .filter(|_| mode == PhaseRewrite::Deserialize)
+            .map(|attrs| attrs.aliases.as_slice())
+            .unwrap_or(&[]);
+
+        for name in std::iter::once(serialized_name).chain(aliases.iter().cloned()) {
+            let widen_tag = mode == PhaseRewrite::Deserialize
+                && variant_attrs.as_ref().is_some_and(|attrs| attrs.other);
+            if widen_tag {
+                return Err(Error::invalid_internally_tagged_variant(
+                    name,
+                    "an external enum payload with `#[serde(other)]` cannot be represented generically inside an internal tag",
+                ));
+            }
+
+            let payload = match &variant.fields {
+                Fields::Unit => Field::new(DataType::Tuple(Tuple::new(vec![]))),
+                _ => variant_payload_field(&variant)
+                    .ok_or_else(|| Error::invalid_external_tagged_variant(name.clone()))?,
+            };
+            let mut transformed_variant = clone_variant_with_named_fields(
+                &variant,
+                vec![(Cow::Owned(name.clone()), payload)],
+            );
+            transformed_variant.attributes = Default::default();
+            transformed
+                .variants
+                .push((Cow::Owned(name), transformed_variant));
+        }
+    }
+
+    transformed
+        .attributes
+        .insert(ENUM_REPR_REWRITTEN_MARKER, true);
+    Ok(DataType::Enum(transformed))
+}
+
+fn substitute_generics(ty: &mut DataType, generics: &[(specta::datatype::Generic, DataType)]) {
+    match ty {
+        DataType::Generic(generic) => {
+            if let Some((_, concrete)) = generics.iter().find(|(candidate, _)| candidate == generic)
+            {
+                *ty = concrete.clone();
+            }
+        }
+        DataType::Struct(strct) => substitute_field_generics(&mut strct.fields, generics),
+        DataType::Enum(enm) => {
+            for (_, variant) in &mut enm.variants {
+                substitute_field_generics(&mut variant.fields, generics);
+            }
+        }
+        DataType::Tuple(tuple) => {
+            for element in &mut tuple.elements {
+                substitute_generics(element, generics);
+            }
+        }
+        DataType::List(list) => substitute_generics(&mut list.ty, generics),
+        DataType::Map(map) => {
+            substitute_generics(map.key_ty_mut(), generics);
+            substitute_generics(map.value_ty_mut(), generics);
+        }
+        DataType::Intersection(parts) => {
+            for part in parts {
+                substitute_generics(part, generics);
+            }
+        }
+        DataType::Nullable(inner) => substitute_generics(inner, generics),
+        DataType::Reference(Reference::Named(reference)) => {
+            for (_, argument) in named_reference_generics_mut(reference) {
+                substitute_generics(argument, generics);
+            }
+            if let NamedReferenceType::Inline { dt, .. } = &mut reference.inner {
+                substitute_generics(dt, generics);
+            }
+        }
+        DataType::Primitive(_) | DataType::Reference(Reference::Opaque(_)) => {}
+    }
+}
+
+fn substitute_field_generics(
+    fields: &mut Fields,
+    generics: &[(specta::datatype::Generic, DataType)],
+) {
+    match fields {
+        Fields::Unit => {}
+        Fields::Unnamed(fields) => {
+            for field in &mut fields.fields {
+                if let Some(ty) = &mut field.ty {
+                    substitute_generics(ty, generics);
+                }
+            }
+        }
+        Fields::Named(fields) => {
+            for (_, field) in &mut fields.fields {
+                if let Some(ty) = &mut field.ty {
+                    substitute_generics(ty, generics);
+                }
+            }
+        }
     }
 }
 
 fn internal_tag_variant_payload_compatibility(
     variant: &Variant,
     original_types: &Types,
-    seen: &mut HashSet<TypeIdentity>,
-) -> Result<Option<bool>, Error> {
+    seen: &mut HashSet<Reference>,
+    mode: PhaseRewrite,
+) -> Result<Option<InternalTagPayloadCompatibility>, Error> {
     match &variant.fields {
-        Fields::Unit => Ok(Some(true)),
-        Fields::Named(named) => Ok(Some(
-            named
+        Fields::Unit => Ok(Some(InternalTagPayloadCompatibility::empty())),
+        Fields::Named(named) => Ok(Some(InternalTagPayloadCompatibility {
+            is_effectively_empty: named
                 .fields
                 .iter()
                 .all(|(_, field)| field.ty.as_ref().is_none()),
-        )),
+            replacement: None,
+        })),
         Fields::Unnamed(unnamed) => {
             if unnamed.fields.len() != 1 {
                 return Ok(None);
@@ -2905,7 +3637,7 @@ fn internal_tag_variant_payload_compatibility(
                 .iter()
                 .find_map(|field| field.ty.as_ref())
                 .map_or(Ok(None), |ty| {
-                    internal_tag_payload_compatibility(ty, original_types, seen)
+                    internal_tag_payload_compatibility(ty, original_types, seen, mode)
                 })
         }
     }

--- a/specta-serde/src/lib.rs
+++ b/specta-serde/src/lib.rs
@@ -2985,6 +2985,12 @@ fn internal_tag_payload_compatibility(
                 let mut is_effectively_empty = true;
                 let mut rewritten = enm.clone();
                 filter_enum_variants_for_phase(&mut rewritten, mode)?;
+                if rewritten.variants.is_empty() {
+                    return Ok(Some(InternalTagPayloadCompatibility {
+                        is_effectively_empty: false,
+                        replacement: Some(DataType::Enum(rewritten)),
+                    }));
+                }
                 let mut changed = rewritten.variants.len() != enm.variants.len();
                 let container_attrs = SerdeContainerAttrs::from_attributes(&enm.attributes)?;
                 for (variant_name, rewritten_variant) in &mut rewritten.variants {

--- a/specta-serde/src/lib.rs
+++ b/specta-serde/src/lib.rs
@@ -3086,9 +3086,10 @@ fn internal_tag_payload_compatibility(
     }
 }
 
-pub(crate) fn internal_tag_payload_requires_contextual_rewrite(
+pub(crate) fn internal_tag_payload_requires_contextual_rewrite_for_mode(
     ty: &DataType,
     types: &Types,
+    mode: PhaseRewrite,
 ) -> Result<bool, Error> {
     enum TransparentPayload<'a> {
         NotTransparent,
@@ -3420,10 +3421,7 @@ pub(crate) fn internal_tag_payload_requires_contextual_rewrite(
         }
     }
 
-    if inner(ty, types, &mut HashSet::new(), PhaseRewrite::Serialize)? {
-        return Ok(true);
-    }
-    inner(ty, types, &mut HashSet::new(), PhaseRewrite::Deserialize)
+    inner(ty, types, &mut HashSet::new(), mode)
 }
 
 fn contextualize_rewritten_external_units(

--- a/specta-serde/src/lib.rs
+++ b/specta-serde/src/lib.rs
@@ -2973,7 +2973,12 @@ fn internal_tag_payload_compatibility(
                     Ok(EnumRepr::Untagged)
                 ) =>
         {
-            Ok(Some(contextualize_rewritten_external_units(enm)?))
+            Ok(Some(contextualize_rewritten_external_units(
+                enm,
+                original_types,
+                seen,
+                mode,
+            )?))
         }
         DataType::Enum(enm) => match EnumRepr::from_attrs(&enm.attributes) {
             Ok(EnumRepr::Untagged) => {
@@ -3380,6 +3385,9 @@ pub(crate) fn internal_tag_payload_requires_contextual_rewrite(
 
 fn contextualize_rewritten_external_units(
     enm: &Enum,
+    original_types: &Types,
+    seen: &mut HashSet<Reference>,
+    mode: PhaseRewrite,
 ) -> Result<InternalTagPayloadCompatibility, Error> {
     let mut rewritten = enm.clone();
     let mut changed = false;
@@ -3410,6 +3418,25 @@ fn contextualize_rewritten_external_units(
             continue;
         }
         if !is_generated_string_literal_datatype(ty) {
+            let Some(compatibility) =
+                internal_tag_payload_compatibility(ty, original_types, seen, mode)?
+            else {
+                return Err(Error::invalid_internally_tagged_variant(
+                    name.clone(),
+                    "an inline untagged payload cannot be merged with an internal tag",
+                ));
+            };
+            if compatibility.is_effectively_empty {
+                *variant = clone_variant_with_unnamed_fields(
+                    variant,
+                    vec![Field::new(named_fields_datatype(Vec::new()))],
+                );
+                changed = true;
+            } else if let Some(replacement) = compatibility.replacement {
+                *variant =
+                    clone_variant_with_unnamed_fields(variant, vec![Field::new(replacement)]);
+                changed = true;
+            }
             continue;
         }
 

--- a/specta-serde/src/lib.rs
+++ b/specta-serde/src/lib.rs
@@ -1774,6 +1774,11 @@ fn unnamed_live_field_count(unnamed: &UnnamedFields) -> usize {
 /// explicitly makes the check exact.
 const ENUM_REPR_REWRITTEN_MARKER: &str = "specta_serde:enum_repr_rewritten";
 
+/// Marker retained when an external variant's serde payload was hidden only
+/// from Specta before the enum was rewritten. The generated string-literal
+/// shape is otherwise indistinguishable from a genuine unit variant.
+const HIDDEN_EXTERNAL_PAYLOAD_MARKER: &str = "specta_serde:hidden_external_payload";
+
 /// Marker retained on a rewritten deserialize-only `#[serde(other)]` branch.
 /// Exporters use it to distinguish the widened catch-all from authored
 /// variant-level untagged branches with an equally broad string field.
@@ -1832,12 +1837,19 @@ fn rewrite_enum_repr_for_phase(
             continue;
         }
 
+        let hidden_external_payload =
+            matches!(repr, EnumRepr::External) && variant_payload_is_hidden(&variant, mode)?;
         if variant_attrs.as_ref().is_some_and(|attrs| attrs.untagged) {
             let mut transformed_variant = transform_untagged_variant(&variant)?;
             // Clear attributes like the other transformed variants below, so
             // later passes (which still filter and walk variants before the
             // marker check) see a plain, already-rewritten variant.
             transformed_variant.attributes = Default::default();
+            if hidden_external_payload {
+                transformed_variant
+                    .attributes
+                    .insert(HIDDEN_EXTERNAL_PAYLOAD_MARKER, true);
+            }
             transformed.push((Cow::Owned(variant_name.into_owned()), transformed_variant));
             continue;
         }
@@ -1886,6 +1898,11 @@ fn rewrite_enum_repr_for_phase(
             };
 
             transformed_variant.attributes = Default::default();
+            if hidden_external_payload {
+                transformed_variant
+                    .attributes
+                    .insert(HIDDEN_EXTERNAL_PAYLOAD_MARKER, true);
+            }
             if widen_tag {
                 transformed_variant
                     .attributes
@@ -2622,24 +2639,17 @@ fn variant_collapses_to_unit(variant: &Variant) -> bool {
     }
 }
 
-/// Whether a tuple variant's payload is *hidden* rather than serde-skipped:
-/// zero live fields, at least one of which lacks a serde skip for the given
-/// phase (`#[specta(skip)]` or a hand-built `Field { ty: None, .. }`). serde
-/// still transports those values on the wire, so no payload shape is known
-/// to the export -- the variant follows the hidden-field convention (payload
-/// omitted) instead of fabricating an `[]` serde would reject. A genuinely
-/// empty tuple variant (`V()`) and an all-serde-skipped one really are `[]`
-/// on the wire and are NOT hidden.
+/// Whether a tuple variant contains a payload slot hidden from Specta but live
+/// for serde in this phase (`#[specta(skip)]` or a hand-built `Field { ty:
+/// None, .. }`). serde still transports that value on the wire, so the export
+/// cannot safely describe even the remaining visible tuple slots. Genuinely
+/// serde-skipped slots are not hidden because they are absent from the wire.
 fn variant_payload_is_hidden(variant: &Variant, mode: PhaseRewrite) -> Result<bool, Error> {
     let Fields::Unnamed(unnamed) = &variant.fields else {
         return Ok(false);
     };
-    if unnamed.fields.is_empty() || unnamed_live_field_count(unnamed) != 0 {
-        return Ok(false);
-    }
-
     for field in &unnamed.fields {
-        if !should_skip_field_for_mode(field, mode)? {
+        if field.ty.is_none() && !should_skip_field_for_mode(field, mode)? {
             return Ok(true);
         }
     }
@@ -3443,6 +3453,15 @@ fn contextualize_rewritten_external_units(
     let mut changed = false;
 
     for (name, variant) in &mut rewritten.variants {
+        if variant
+            .attributes
+            .contains_key(HIDDEN_EXTERNAL_PAYLOAD_MARKER)
+        {
+            return Err(Error::invalid_internally_tagged_variant(
+                name.clone(),
+                "a payload hidden only from Specta cannot be represented inside an internal tag",
+            ));
+        }
         let Fields::Unnamed(fields) = &variant.fields else {
             continue;
         };
@@ -3530,6 +3549,9 @@ fn external_enum_requires_contextual_rewrite(
             .as_ref()
             .is_some_and(|attrs| attrs.other || attrs.untagged)
         {
+            return Ok(true);
+        }
+        if variant_payload_is_hidden(variant, mode)? {
             return Ok(true);
         }
 

--- a/specta-serde/src/lib.rs
+++ b/specta-serde/src/lib.rs
@@ -3649,12 +3649,12 @@ fn external_enum_tagged_payload_datatype(
             serialized_variant_name(variant_name, &variant, &container_attrs, mode)?;
         let aliases = variant_attrs
             .as_ref()
-            .filter(|_| mode == PhaseRewrite::Deserialize)
+            .filter(|_| matches!(mode, PhaseRewrite::Unified | PhaseRewrite::Deserialize))
             .map(|attrs| attrs.aliases.as_slice())
             .unwrap_or(&[]);
 
         for name in std::iter::once(serialized_name).chain(aliases.iter().cloned()) {
-            let widen_tag = mode == PhaseRewrite::Deserialize
+            let widen_tag = matches!(mode, PhaseRewrite::Unified | PhaseRewrite::Deserialize)
                 && variant_attrs.as_ref().is_some_and(|attrs| attrs.other);
             if widen_tag {
                 return Err(Error::invalid_internally_tagged_variant(

--- a/specta-serde/src/lib.rs
+++ b/specta-serde/src/lib.rs
@@ -2986,7 +2986,50 @@ fn internal_tag_payload_compatibility(
                 let mut rewritten = enm.clone();
                 filter_enum_variants_for_phase(&mut rewritten, mode)?;
                 let mut changed = rewritten.variants.len() != enm.variants.len();
-                for (_, rewritten_variant) in &mut rewritten.variants {
+                let container_attrs = SerdeContainerAttrs::from_attributes(&enm.attributes)?;
+                for (variant_name, rewritten_variant) in &mut rewritten.variants {
+                    let original_fields = rewritten_variant.fields.clone();
+                    let rename_rule = enum_variant_field_rename_rule(
+                        &container_attrs,
+                        rewritten_variant,
+                        mode,
+                        variant_name,
+                    )?;
+                    let conditional_omission_applies = !matches!(
+                        &rewritten_variant.fields,
+                        Fields::Unnamed(unnamed) if unnamed.fields.len() == 1
+                    );
+                    rewrite_fields_for_phase(
+                        &mut rewritten_variant.fields,
+                        mode,
+                        original_types,
+                        &HashMap::new(),
+                        &HashSet::new(),
+                        rename_rule,
+                        false,
+                        true,
+                        conditional_omission_applies,
+                    )?;
+
+                    let lowered = if matches!(
+                        &rewritten_variant.fields,
+                        Fields::Named(fields) if fields.fields.iter().any(|(_, field)| field_is_flattened(field))
+                    ) {
+                        let mut payload = Struct::unit();
+                        std::mem::swap(&mut payload.fields, &mut rewritten_variant.fields);
+                        lower_flattened_struct(&mut payload, mode)?
+                    } else {
+                        lower_field_aliases_for_phase(&mut rewritten_variant.fields, mode)?
+                    };
+                    if let Some(payload) = lowered {
+                        rewritten_variant.fields = clone_variant_with_unnamed_fields(
+                            rewritten_variant,
+                            vec![Field::new(payload)],
+                        )
+                        .fields;
+                    }
+                    changed |= rewritten_variant.fields != original_fields;
+
                     let variant = rewritten_variant.clone();
                     let Some(variant_payload) = internal_tag_variant_payload_compatibility(
                         &variant,

--- a/specta-serde/src/parser.rs
+++ b/specta-serde/src/parser.rs
@@ -17,11 +17,11 @@ const CONTAINER_UNTAGGED: &str = "serde:container:untagged";
 const CONTAINER_DEFAULT: &str = "serde:container:default";
 const CONTAINER_TRANSPARENT: &str = "serde:container:transparent";
 const CONTAINER_FROM_TYPE_SRC: &str = "serde:container:from_type_src";
-const CONTAINER_FROM_RESOLVED: &str = "serde:container:from_resolved";
+pub(crate) const CONTAINER_FROM_RESOLVED: &str = "serde:container:from_resolved";
 const CONTAINER_TRY_FROM_TYPE_SRC: &str = "serde:container:try_from_type_src";
-const CONTAINER_TRY_FROM_RESOLVED: &str = "serde:container:try_from_resolved";
+pub(crate) const CONTAINER_TRY_FROM_RESOLVED: &str = "serde:container:try_from_resolved";
 const CONTAINER_INTO_TYPE_SRC: &str = "serde:container:into_type_src";
-const CONTAINER_INTO_RESOLVED: &str = "serde:container:into_resolved";
+pub(crate) const CONTAINER_INTO_RESOLVED: &str = "serde:container:into_resolved";
 const CONTAINER_VARIANT_IDENTIFIER: &str = "serde:container:variant_identifier";
 const CONTAINER_FIELD_IDENTIFIER: &str = "serde:container:field_identifier";
 

--- a/specta-serde/src/validate.rs
+++ b/specta-serde/src/validate.rs
@@ -327,14 +327,7 @@ fn inner(
                 ));
             }
             validate_identifier_enum(enm, &path, mode)?;
-            validate_enum(
-                enm,
-                types,
-                path.clone(),
-                mode,
-                declared_directions.deserialize,
-                env,
-            )?;
+            validate_enum(enm, types, path.clone(), mode, declared_directions, env)?;
             if variant_names_emitted {
                 validate_variant_aliases(
                     enm,
@@ -1751,7 +1744,7 @@ fn validate_enum(
     types: &Types,
     path: String,
     mode: ApplyMode,
-    declared_deserializes: bool,
+    declared_directions: FlattenDirections,
     env: Option<&GenericEnv<'_>>,
 ) -> Result<(), Error> {
     let valid_variants = enm
@@ -1769,11 +1762,18 @@ fn validate_enum(
     let repr = EnumRepr::from_attrs(&enm.attributes)?;
 
     validate_untagged_variants(enm, &path)?;
-    validate_other_variant(enm, &path, &repr, mode, declared_deserializes)?;
+    validate_other_variant(enm, &path, &repr, mode, declared_directions.deserialize)?;
     validate_adjacent_collapsed_newtype_variants(enm, &path, &repr, mode)?;
 
     if matches!(repr, EnumRepr::Internal { .. }) {
-        validate_internally_tag_enum(enm, types, path, &mut HashSet::new(), env)?;
+        validate_internally_tag_enum(
+            enm,
+            types,
+            path,
+            &mut HashSet::new(),
+            env,
+            declared_directions,
+        )?;
     }
 
     Ok(())
@@ -1956,9 +1956,19 @@ fn validate_internally_tag_enum(
     path: String,
     seen: &mut HashSet<Reference>,
     env: Option<&GenericEnv<'_>>,
+    directions: FlattenDirections,
 ) -> Result<(), Error> {
     for (variant_name, variant) in &enm.variants {
-        validate_internally_tag_variant(enm, variant_name, variant, types, &path, seen, env)?;
+        validate_internally_tag_variant(
+            enm,
+            variant_name,
+            variant,
+            types,
+            &path,
+            seen,
+            env,
+            directions.and(FlattenDirections::for_variant(variant)?),
+        )?;
     }
 
     Ok(())
@@ -1972,7 +1982,12 @@ fn validate_internally_tag_variant(
     path: &str,
     seen: &mut HashSet<Reference>,
     env: Option<&GenericEnv<'_>>,
+    directions: FlattenDirections,
 ) -> Result<(), Error> {
+    if !directions.serialize && !directions.deserialize {
+        return Ok(());
+    }
+
     let _ = enm;
     if SerdeVariantAttrs::from_attributes(&variant.attributes)?.is_some_and(|attrs| attrs.untagged)
     {
@@ -2006,6 +2021,7 @@ fn validate_internally_tag_variant(
                 seen,
                 env,
                 true,
+                directions,
             )
         }
     }
@@ -2023,7 +2039,12 @@ fn validate_internally_tag_enum_datatype(
     seen: &mut HashSet<Reference>,
     env: Option<&GenericEnv<'_>>,
     reject_contextual_generic_argument: bool,
+    directions: FlattenDirections,
 ) -> Result<(), Error> {
+    if !directions.serialize && !directions.deserialize {
+        return Ok(());
+    }
+
     match ty {
         DataType::Map(_) => Ok(()),
         DataType::Struct(strct)
@@ -2035,36 +2056,30 @@ fn validate_internally_tag_enum_datatype(
                 Fields::Unit => {}
                 Fields::Unnamed(unnamed) => {
                     for field in &unnamed.fields {
-                        let attrs = SerdeFieldAttrs::from_attributes(&field.attributes)?;
-                        if attrs
-                            .as_ref()
-                            .is_some_and(|attrs| attrs.skip_serializing || attrs.skip_deserializing)
-                        {
+                        let field_directions = directions.and(FlattenDirections::for_field(field)?);
+                        if !field_directions.serialize && !field_directions.deserialize {
                             continue;
                         }
                         if let Some(ty) = &field.ty {
-                            live_fields.push(ty);
+                            live_fields.push((ty, field_directions));
                         }
                     }
                 }
                 Fields::Named(named) => {
                     for (_, field) in &named.fields {
-                        let attrs = SerdeFieldAttrs::from_attributes(&field.attributes)?;
-                        if attrs
-                            .as_ref()
-                            .is_some_and(|attrs| attrs.skip_serializing || attrs.skip_deserializing)
-                        {
+                        let field_directions = directions.and(FlattenDirections::for_field(field)?);
+                        if !field_directions.serialize && !field_directions.deserialize {
                             continue;
                         }
                         if let Some(ty) = &field.ty {
-                            live_fields.push(ty);
+                            live_fields.push((ty, field_directions));
                         }
                     }
                 }
             }
 
             match live_fields.as_slice() {
-                [ty] => validate_internally_tag_enum_datatype(
+                [(ty, field_directions)] => validate_internally_tag_enum_datatype(
                     ty,
                     types,
                     path,
@@ -2072,6 +2087,7 @@ fn validate_internally_tag_enum_datatype(
                     seen,
                     env,
                     reject_contextual_generic_argument,
+                    *field_directions,
                 ),
                 [] => Ok(()),
                 _ => Err(Error::invalid_internally_tagged_enum(
@@ -2084,7 +2100,8 @@ fn validate_internally_tag_enum_datatype(
         DataType::Struct(strct) => match &strct.fields {
             Fields::Unit | Fields::Named(_) => Ok(()),
             Fields::Unnamed(unnamed) if unnamed.fields.len() == 1 => {
-                unnamed.fields[0].ty.as_ref().map_or(Ok(()), |ty| {
+                let field = &unnamed.fields[0];
+                field.ty.as_ref().map_or(Ok(()), |ty| {
                     validate_internally_tag_enum_datatype(
                         ty,
                         types,
@@ -2093,6 +2110,7 @@ fn validate_internally_tag_enum_datatype(
                         seen,
                         env,
                         reject_contextual_generic_argument,
+                        directions.and(FlattenDirections::for_field(field)?),
                     )
                 })
             }
@@ -2121,6 +2139,7 @@ fn validate_internally_tag_enum_datatype(
                         seen,
                         env,
                         reject_contextual_generic_argument,
+                        directions,
                     )
                 }
                 NamedReferenceType::Reference { generics, .. } => {
@@ -2143,6 +2162,7 @@ fn validate_internally_tag_enum_datatype(
                                     parent: env,
                                 }),
                                 reject_contextual_generic_argument,
+                                directions,
                             )
                         })
                 }
@@ -2154,7 +2174,7 @@ fn validate_internally_tag_enum_datatype(
         }
         DataType::Enum(enm) => match EnumRepr::from_attrs(&enm.attributes)? {
             EnumRepr::Untagged => {
-                validate_internally_tag_enum(enm, types, path.to_string(), seen, env)
+                validate_internally_tag_enum(enm, types, path.to_string(), seen, env, directions)
             }
             EnumRepr::External | EnumRepr::Internal { .. } | EnumRepr::Adjacent { .. } => Ok(()),
         },
@@ -2162,9 +2182,19 @@ fn validate_internally_tag_enum_datatype(
         DataType::Generic(generic) => {
             match env.and_then(|env| env.map.iter().find(|(param, _)| param == generic)) {
                 Some((_, argument)) => {
-                    if reject_contextual_generic_argument
-                        && crate::internal_tag_payload_requires_contextual_rewrite(argument, types)?
-                    {
+                    let requires_contextual_rewrite = (directions.serialize
+                        && crate::internal_tag_payload_requires_contextual_rewrite_for_mode(
+                            argument,
+                            types,
+                            PhaseRewrite::Serialize,
+                        )?)
+                        || (directions.deserialize
+                            && crate::internal_tag_payload_requires_contextual_rewrite_for_mode(
+                                argument,
+                                types,
+                                PhaseRewrite::Deserialize,
+                            )?);
+                    if reject_contextual_generic_argument && requires_contextual_rewrite {
                         return Err(Error::invalid_internally_tagged_enum(
                             path,
                             variant_name,
@@ -2180,6 +2210,7 @@ fn validate_internally_tag_enum_datatype(
                         seen,
                         env.and_then(|env| env.parent),
                         reject_contextual_generic_argument,
+                        directions,
                     )
                 }
                 None => Ok(()),

--- a/specta-serde/src/validate.rs
+++ b/specta-serde/src/validate.rs
@@ -42,6 +42,23 @@ pub fn validate_for_mode(types: &Types, mode: ApplyMode) -> Result<(), Error> {
         )?;
     }
 
+    // Generic definitions are necessarily conditional: an internally tagged
+    // `E<T> { V(T) }` is valid for map-like `T` and invalid for scalar `T`.
+    // Walk registered roots as use sites so their concrete generic arguments
+    // are available through `GenericEnv` when following the named reference.
+    for root in types.roots() {
+        inner(
+            root,
+            types,
+            &mut HashSet::new(),
+            "<root>".to_string(),
+            mode,
+            true,
+            None,
+            FlattenDirections::LIVE,
+        )?;
+    }
+
     Ok(())
 }
 
@@ -316,6 +333,7 @@ fn inner(
                 path.clone(),
                 mode,
                 declared_directions.deserialize,
+                env,
             )?;
             if variant_names_emitted {
                 validate_variant_aliases(
@@ -1734,6 +1752,7 @@ fn validate_enum(
     path: String,
     mode: ApplyMode,
     declared_deserializes: bool,
+    env: Option<&GenericEnv<'_>>,
 ) -> Result<(), Error> {
     let valid_variants = enm
         .variants
@@ -1754,7 +1773,7 @@ fn validate_enum(
     validate_adjacent_collapsed_newtype_variants(enm, &path, &repr, mode)?;
 
     if matches!(repr, EnumRepr::Internal { .. }) {
-        validate_internally_tag_enum(enm, types, path, &mut HashSet::new())?;
+        validate_internally_tag_enum(enm, types, path, &mut HashSet::new(), env)?;
     }
 
     Ok(())
@@ -1936,9 +1955,10 @@ fn validate_internally_tag_enum(
     types: &Types,
     path: String,
     seen: &mut HashSet<Reference>,
+    env: Option<&GenericEnv<'_>>,
 ) -> Result<(), Error> {
     for (variant_name, variant) in &enm.variants {
-        validate_internally_tag_variant(enm, variant_name, variant, types, &path, seen)?;
+        validate_internally_tag_variant(enm, variant_name, variant, types, &path, seen, env)?;
     }
 
     Ok(())
@@ -1951,6 +1971,7 @@ fn validate_internally_tag_variant(
     types: &Types,
     path: &str,
     seen: &mut HashSet<Reference>,
+    env: Option<&GenericEnv<'_>>,
 ) -> Result<(), Error> {
     let _ = enm;
     if SerdeVariantAttrs::from_attributes(&variant.attributes)?.is_some_and(|attrs| attrs.untagged)
@@ -1977,7 +1998,15 @@ fn validate_internally_tag_variant(
                 ));
             }
 
-            validate_internally_tag_enum_datatype(first_field, types, path, variant_name, seen)
+            validate_internally_tag_enum_datatype(
+                first_field,
+                types,
+                path,
+                variant_name,
+                seen,
+                env,
+                true,
+            )
         }
     }
 }
@@ -1992,31 +2021,171 @@ fn validate_internally_tag_enum_datatype(
     path: &str,
     variant_name: &str,
     seen: &mut HashSet<Reference>,
+    env: Option<&GenericEnv<'_>>,
+    reject_contextual_generic_argument: bool,
 ) -> Result<(), Error> {
     match ty {
         DataType::Map(_) => Ok(()),
-        DataType::Struct(_) => Ok(()),
+        DataType::Struct(strct)
+            if SerdeContainerAttrs::from_attributes(&strct.attributes)?
+                .is_some_and(|attrs| attrs.transparent) =>
+        {
+            let mut live_fields = Vec::new();
+            match &strct.fields {
+                Fields::Unit => {}
+                Fields::Unnamed(unnamed) => {
+                    for field in &unnamed.fields {
+                        let attrs = SerdeFieldAttrs::from_attributes(&field.attributes)?;
+                        if attrs
+                            .as_ref()
+                            .is_some_and(|attrs| attrs.skip_serializing || attrs.skip_deserializing)
+                        {
+                            continue;
+                        }
+                        if let Some(ty) = &field.ty {
+                            live_fields.push(ty);
+                        }
+                    }
+                }
+                Fields::Named(named) => {
+                    for (_, field) in &named.fields {
+                        let attrs = SerdeFieldAttrs::from_attributes(&field.attributes)?;
+                        if attrs
+                            .as_ref()
+                            .is_some_and(|attrs| attrs.skip_serializing || attrs.skip_deserializing)
+                        {
+                            continue;
+                        }
+                        if let Some(ty) = &field.ty {
+                            live_fields.push(ty);
+                        }
+                    }
+                }
+            }
+
+            match live_fields.as_slice() {
+                [ty] => validate_internally_tag_enum_datatype(
+                    ty,
+                    types,
+                    path,
+                    variant_name,
+                    seen,
+                    env,
+                    reject_contextual_generic_argument,
+                ),
+                [] => Ok(()),
+                _ => Err(Error::invalid_internally_tagged_enum(
+                    path,
+                    variant_name,
+                    "payload cannot be merged with an internal tag",
+                )),
+            }
+        }
+        DataType::Struct(strct) => match &strct.fields {
+            Fields::Unit | Fields::Named(_) => Ok(()),
+            Fields::Unnamed(unnamed) if unnamed.fields.len() == 1 => {
+                unnamed.fields[0].ty.as_ref().map_or(Ok(()), |ty| {
+                    validate_internally_tag_enum_datatype(
+                        ty,
+                        types,
+                        path,
+                        variant_name,
+                        seen,
+                        env,
+                        reject_contextual_generic_argument,
+                    )
+                })
+            }
+            Fields::Unnamed(_) => Err(Error::invalid_internally_tagged_enum(
+                path,
+                variant_name,
+                "payload cannot be merged with an internal tag",
+            )),
+        },
         DataType::Reference(Reference::Named(reference)) => {
-            let key = Reference::Named(reference.clone());
+            let key = resolved_reference_key(reference, env);
             if !seen.insert(key.clone()) {
                 return Ok(());
             }
 
-            let result = named_reference_ty(reference, types).map_or(Ok(()), |ty| {
-                let path = inner_reference_path(path, reference, types);
-                validate_internally_tag_enum_datatype(ty, types, &path, variant_name, seen)
-            });
+            let path = inner_reference_path(path, reference, types);
+            let result = match &reference.inner {
+                NamedReferenceType::Inline { dt, .. } => {
+                    let reject_contextual_generic_argument =
+                        reject_contextual_generic_argument && datatype_changes_under_env(dt, env);
+                    validate_internally_tag_enum_datatype(
+                        dt,
+                        types,
+                        &path,
+                        variant_name,
+                        seen,
+                        env,
+                        reject_contextual_generic_argument,
+                    )
+                }
+                NamedReferenceType::Reference { generics, .. } => {
+                    let reject_contextual_generic_argument = reject_contextual_generic_argument
+                        && generics
+                            .iter()
+                            .any(|(_, argument)| datatype_changes_under_env(argument, env));
+                    types
+                        .get(reference)
+                        .and_then(|ndt| ndt.ty.as_ref())
+                        .map_or(Ok(()), |ty| {
+                            validate_internally_tag_enum_datatype(
+                                ty,
+                                types,
+                                &path,
+                                variant_name,
+                                seen,
+                                Some(&GenericEnv {
+                                    map: generics,
+                                    parent: env,
+                                }),
+                                reject_contextual_generic_argument,
+                            )
+                        })
+                }
+                NamedReferenceType::Recursive(_) => Ok(()),
+            };
             seen.remove(&key);
 
             result
         }
         DataType::Enum(enm) => match EnumRepr::from_attrs(&enm.attributes)? {
-            EnumRepr::Untagged => validate_internally_tag_enum(enm, types, path.to_string(), seen),
+            EnumRepr::Untagged => {
+                validate_internally_tag_enum(enm, types, path.to_string(), seen, env)
+            }
             EnumRepr::External | EnumRepr::Internal { .. } | EnumRepr::Adjacent { .. } => Ok(()),
         },
         DataType::Tuple(tuple) if tuple.elements.is_empty() => Ok(()),
+        DataType::Generic(generic) => {
+            match env.and_then(|env| env.map.iter().find(|(param, _)| param == generic)) {
+                Some((_, argument)) => {
+                    if reject_contextual_generic_argument
+                        && crate::internal_tag_payload_requires_contextual_rewrite(argument, types)?
+                    {
+                        return Err(Error::invalid_internally_tagged_enum(
+                            path,
+                            variant_name,
+                            "a concrete generic payload requires context-sensitive enum encoding; use a non-generic wrapper variant",
+                        ));
+                    }
+
+                    validate_internally_tag_enum_datatype(
+                        argument,
+                        types,
+                        path,
+                        variant_name,
+                        seen,
+                        env.and_then(|env| env.parent),
+                        reject_contextual_generic_argument,
+                    )
+                }
+                None => Ok(()),
+            }
+        }
         DataType::Reference(Reference::Opaque(_))
-        | DataType::Generic(_)
         | DataType::Intersection(_)
         | DataType::Tuple(_)
         | DataType::Primitive(_)
@@ -2027,6 +2196,12 @@ fn validate_internally_tag_enum_datatype(
             "payload cannot be merged with an internal tag",
         )),
     }
+}
+
+fn datatype_changes_under_env(ty: &DataType, env: Option<&GenericEnv<'_>>) -> bool {
+    let mut resolved = ty.clone();
+    let mut budget = RESOLVED_KEY_NODE_BUDGET;
+    resolve_generics_for_key(&mut resolved, env, &mut budget) && resolved != *ty
 }
 
 /// Extends `path` with the name of the type behind a named reference, so an

--- a/specta-serde/src/validate.rs
+++ b/specta-serde/src/validate.rs
@@ -1995,7 +1995,22 @@ fn validate_internally_tag_variant(
     }
 
     match &variant.fields {
-        Fields::Unit | Fields::Named(_) => Ok(()),
+        Fields::Unit => Ok(()),
+        Fields::Named(named) => {
+            for (_, field) in &named.fields {
+                let field_directions = directions.and(FlattenDirections::for_field(field)?);
+                if field.ty.is_none()
+                    && (field_directions.serialize || field_directions.deserialize)
+                {
+                    return Err(Error::invalid_internally_tagged_enum(
+                        path,
+                        variant_name,
+                        "a payload hidden only from Specta cannot be merged with an internal tag",
+                    ));
+                }
+            }
+            Ok(())
+        }
         Fields::Unnamed(unnamed) => {
             let mut fields = unnamed
                 .fields
@@ -2045,6 +2060,32 @@ fn validate_internally_tag_enum_datatype(
         return Ok(());
     }
 
+    let attrs = match ty {
+        DataType::Struct(strct) => SerdeContainerAttrs::from_attributes(&strct.attributes)?,
+        DataType::Enum(enm) => SerdeContainerAttrs::from_attributes(&enm.attributes)?,
+        _ => None,
+    };
+    let directions = match conversion_wire_targets(attrs.as_ref()) {
+        Some((serialize_wire, deserialize_wire)) => {
+            let remaining = validate_internally_tag_conversion_wires(
+                serialize_wire,
+                deserialize_wire,
+                types,
+                path,
+                variant_name,
+                seen,
+                env,
+                reject_contextual_generic_argument,
+                directions,
+            )?;
+            if !remaining.serialize && !remaining.deserialize {
+                return Ok(());
+            }
+            remaining
+        }
+        None => directions,
+    };
+
     match ty {
         DataType::Map(_) => Ok(()),
         DataType::Struct(strct)
@@ -2060,9 +2101,14 @@ fn validate_internally_tag_enum_datatype(
                         if !field_directions.serialize && !field_directions.deserialize {
                             continue;
                         }
-                        if let Some(ty) = &field.ty {
-                            live_fields.push((ty, field_directions));
-                        }
+                        let Some(ty) = &field.ty else {
+                            return Err(Error::invalid_internally_tagged_enum(
+                                path,
+                                variant_name,
+                                "a payload hidden only from Specta cannot be merged with an internal tag",
+                            ));
+                        };
+                        live_fields.push((ty, field_directions));
                     }
                 }
                 Fields::Named(named) => {
@@ -2071,9 +2117,14 @@ fn validate_internally_tag_enum_datatype(
                         if !field_directions.serialize && !field_directions.deserialize {
                             continue;
                         }
-                        if let Some(ty) = &field.ty {
-                            live_fields.push((ty, field_directions));
-                        }
+                        let Some(ty) = &field.ty else {
+                            return Err(Error::invalid_internally_tagged_enum(
+                                path,
+                                variant_name,
+                                "a payload hidden only from Specta cannot be merged with an internal tag",
+                            ));
+                        };
+                        live_fields.push((ty, field_directions));
                     }
                 }
             }
@@ -2098,11 +2149,27 @@ fn validate_internally_tag_enum_datatype(
             }
         }
         DataType::Struct(strct) => match &strct.fields {
-            Fields::Unit | Fields::Named(_) => Ok(()),
+            Fields::Unit => Ok(()),
+            Fields::Named(named) => {
+                for (_, field) in &named.fields {
+                    let field_directions = directions.and(FlattenDirections::for_field(field)?);
+                    if field.ty.is_none()
+                        && (field_directions.serialize || field_directions.deserialize)
+                    {
+                        return Err(Error::invalid_internally_tagged_enum(
+                            path,
+                            variant_name,
+                            "a payload hidden only from Specta cannot be merged with an internal tag",
+                        ));
+                    }
+                }
+                Ok(())
+            }
             Fields::Unnamed(unnamed) if unnamed.fields.len() == 1 => {
                 let field = &unnamed.fields[0];
-                field.ty.as_ref().map_or(Ok(()), |ty| {
-                    validate_internally_tag_enum_datatype(
+                let field_directions = directions.and(FlattenDirections::for_field(field)?);
+                match field.ty.as_ref() {
+                    Some(ty) => validate_internally_tag_enum_datatype(
                         ty,
                         types,
                         path,
@@ -2110,9 +2177,15 @@ fn validate_internally_tag_enum_datatype(
                         seen,
                         env,
                         reject_contextual_generic_argument,
-                        directions.and(FlattenDirections::for_field(field)?),
-                    )
-                })
+                        field_directions,
+                    ),
+                    None if !field_directions.serialize && !field_directions.deserialize => Ok(()),
+                    None => Err(Error::invalid_internally_tagged_enum(
+                        path,
+                        variant_name,
+                        "a payload hidden only from Specta cannot be merged with an internal tag",
+                    )),
+                }
             }
             Fields::Unnamed(_) => Err(Error::invalid_internally_tagged_enum(
                 path,
@@ -2227,6 +2300,53 @@ fn validate_internally_tag_enum_datatype(
             "payload cannot be merged with an internal tag",
         )),
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn validate_internally_tag_conversion_wires(
+    serialize_wire: Option<&DataType>,
+    deserialize_wire: Option<&DataType>,
+    types: &Types,
+    path: &str,
+    variant_name: &str,
+    seen: &mut HashSet<Reference>,
+    env: Option<&GenericEnv<'_>>,
+    reject_contextual_generic_argument: bool,
+    directions: FlattenDirections,
+) -> Result<FlattenDirections, Error> {
+    if directions.serialize
+        && let Some(wire) = serialize_wire
+    {
+        validate_internally_tag_enum_datatype(
+            wire,
+            types,
+            path,
+            variant_name,
+            seen,
+            env,
+            reject_contextual_generic_argument,
+            FlattenDirections::SERIALIZE_ONLY,
+        )?;
+    }
+    if directions.deserialize
+        && let Some(wire) = deserialize_wire
+    {
+        validate_internally_tag_enum_datatype(
+            wire,
+            types,
+            path,
+            variant_name,
+            seen,
+            env,
+            reject_contextual_generic_argument,
+            FlattenDirections::DESERIALIZE_ONLY,
+        )?;
+    }
+
+    Ok(FlattenDirections {
+        serialize: directions.serialize && serialize_wire.is_none(),
+        deserialize: directions.deserialize && deserialize_wire.is_none(),
+    })
 }
 
 fn datatype_changes_under_env(ty: &DataType, env: Option<&GenericEnv<'_>>) -> bool {

--- a/tests/tests/mod.rs
+++ b/tests/tests/mod.rs
@@ -36,6 +36,7 @@ mod serde_empty_payloads;
 mod serde_enum_rewrite;
 mod serde_flatten_option;
 mod serde_identifiers;
+mod serde_internal_tag_payloads;
 mod serde_other;
 mod serde_unified_asymmetry;
 mod serde_unknown_attrs;

--- a/tests/tests/serde_internal_tag_payloads.rs
+++ b/tests/tests/serde_internal_tag_payloads.rs
@@ -94,6 +94,16 @@ enum ExternalWithoutUnit {
     Struct { value: i32 },
 }
 
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+enum DirectionalExternalUnit {
+    #[serde(skip_serializing)]
+    Unit,
+    Live {
+        value: i32,
+    },
+}
+
 #[derive(Debug, PartialEq, Type, Serialize, Deserialize)]
 #[specta(collect = false)]
 #[serde(tag = "kind")]
@@ -253,6 +263,13 @@ enum ExternalWithUntaggedUnit {
 enum ExternalWithUntaggedEmptyStruct {
     #[serde(untagged)]
     Empty {},
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+enum UntaggedDirectionalMap {
+    #[serde(untagged)]
+    Value(#[serde(skip_serializing)] Inner),
 }
 
 #[derive(Type, Serialize, Deserialize)]
@@ -425,6 +442,22 @@ fn format_accepts_newtype_unit_and_generic_payloads() {
     let err = specta_serde::Format
         .map_types(&Types::default().register::<GenericPayload<ExternalWithUntaggedUnit>>())
         .expect_err("an untagged unit contributes no payload under TaggedSerializer");
+    assert!(
+        err.to_string().contains("context-sensitive enum encoding"),
+        "unexpected error: {err}"
+    );
+
+    let err = specta_serde::PhasesFormat
+        .map_types(&Types::default().register::<GenericPayload<DirectionalExternalUnit>>())
+        .expect_err("deserialize-only unit variants still need contextual generic encoding");
+    assert!(
+        err.to_string().contains("context-sensitive enum encoding"),
+        "unexpected error: {err}"
+    );
+
+    let err = specta_serde::PhasesFormat
+        .map_types(&Types::default().register::<GenericPayload<UntaggedDirectionalMap>>())
+        .expect_err("a phase-skipped untagged newtype becomes a contextual unit contribution");
     assert!(
         err.to_string().contains("context-sensitive enum encoding"),
         "unexpected error: {err}"

--- a/tests/tests/serde_internal_tag_payloads.rs
+++ b/tests/tests/serde_internal_tag_payloads.rs
@@ -73,6 +73,23 @@ enum GenericPayload<T> {
 #[derive(Type, Serialize, Deserialize)]
 #[specta(collect = false)]
 #[serde(tag = "kind")]
+enum SerializeOnlyGenericPayload<T> {
+    #[serde(skip_deserializing)]
+    Value(T),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum GenericPayloadWithSkippedScalar<T> {
+    #[serde(skip)]
+    Dead(T),
+    Live,
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
 enum WrappedGenericPayload<T> {
     Value(GenericNewtype<T>),
 }
@@ -508,6 +525,14 @@ fn format_accepts_newtype_unit_and_generic_payloads() {
     specta_serde::Format
         .map_types(&Types::default().register::<GenericPayload<ExternalWithUntaggedEmptyStruct>>())
         .expect("an untagged empty object already merges with an internal tag correctly");
+    specta_serde::PhasesFormat
+        .map_types(
+            &Types::default().register::<SerializeOnlyGenericPayload<DirectionalExternalUnit>>(),
+        )
+        .expect("contextual generic checks must ignore a phase where the outer variant is skipped");
+    specta_serde::Format
+        .map_types(&Types::default().register::<GenericPayloadWithSkippedScalar<i32>>())
+        .expect("fully skipped variants must not validate their dead scalar payload");
 
     let err = specta_serde::Format
         .map_types(&Types::default().register::<GenericPayload<i32>>())

--- a/tests/tests/serde_internal_tag_payloads.rs
+++ b/tests/tests/serde_internal_tag_payloads.rs
@@ -177,6 +177,7 @@ enum NestedGenericNewtypeExternalWrapper {
 #[derive(Type, Serialize, Deserialize)]
 #[specta(collect = false)]
 enum ExternalWithSerdeAttrs {
+    #[serde(alias = "OldRenamed")]
     Renamed {
         #[serde(rename = "wire_value")]
         value: i32,
@@ -779,6 +780,14 @@ fn contextual_external_enum_applies_serde_field_and_variant_semantics() {
         .unwrap(),
         serde_json::json!({ "kind": "Value", "raw_value": 1 })
     );
+    assert!(matches!(
+        serde_json::from_value::<ExternalWithSerdeAttrsWrapper>(serde_json::json!({
+            "kind": "Value",
+            "OldRenamed": { "wire_value": 1 },
+        }))
+        .unwrap(),
+        ExternalWithSerdeAttrsWrapper::Value(ExternalWithSerdeAttrs::Renamed { value: 1 })
+    ));
 
     let types = Types::default().register::<ExternalWithSerdeAttrsWrapper>();
     let mapped = specta_serde::Format
@@ -794,6 +803,10 @@ fn contextual_external_enum_applies_serde_field_and_variant_semantics() {
     assert!(contains_named_field(wrapper, "wire_value", |ty| matches!(
         ty,
         DataType::Primitive(specta::datatype::Primitive::i32)
+    )));
+    assert!(contains_named_field(wrapper, "OldRenamed", |ty| matches!(
+        ty,
+        DataType::Struct(_)
     )));
     assert!(contains_named_field(wrapper, "Skipped", |ty| matches!(
         ty,
@@ -1082,6 +1095,12 @@ fn nested_untagged_enum_propagates_contextual_external_shape() {
 
 #[test]
 fn inline_external_other_is_rejected_in_contextual_deserialize_shape() {
+    assert!(
+        specta_serde::Format
+            .map_types(&Types::default().register::<InlineExternalWithOtherWrapper>())
+            .is_err(),
+        "unified contextual payloads cannot represent an arbitrary inner map key"
+    );
     assert!(
         specta_serde::PhasesFormat
             .map_types(&Types::default().register::<InlineExternalWithOtherWrapper>())

--- a/tests/tests/serde_internal_tag_payloads.rs
+++ b/tests/tests/serde_internal_tag_payloads.rs
@@ -21,6 +21,31 @@ struct Unit;
 
 #[derive(Type, Serialize, Deserialize)]
 #[specta(collect = false)]
+struct ConvertedMapWire {
+    converted_value: i32,
+}
+
+#[derive(Clone, Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(into = "ConvertedMapWire", from = "ConvertedMapWire")]
+struct ConvertedScalar(i32);
+
+impl From<ConvertedScalar> for ConvertedMapWire {
+    fn from(value: ConvertedScalar) -> Self {
+        Self {
+            converted_value: value.0,
+        }
+    }
+}
+
+impl From<ConvertedMapWire> for ConvertedScalar {
+    fn from(value: ConvertedMapWire) -> Self {
+        Self(value.converted_value)
+    }
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
 struct HiddenNewtype(#[specta(skip)] i32);
 
 #[derive(Type, Serialize, Deserialize)]
@@ -45,6 +70,13 @@ enum NewtypePayloads {
 #[derive(Type, Serialize, Deserialize)]
 #[specta(collect = false)]
 #[serde(tag = "kind")]
+enum ConvertedPayloadWrapper {
+    Value(ConvertedScalar),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
 enum HiddenNewtypePayload {
     Value(HiddenNewtype),
 }
@@ -54,6 +86,16 @@ enum HiddenNewtypePayload {
 #[serde(tag = "kind")]
 enum DirectHiddenPayload {
     Value(#[specta(skip)] i32),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum DirectHiddenNamedPayload {
+    Value {
+        #[specta(skip)]
+        value: i32,
+    },
 }
 
 #[derive(Type, Serialize, Deserialize)]
@@ -529,6 +571,14 @@ fn serde_accepts_newtype_and_unit_struct_payloads() {
         .unwrap(),
         serde_json::json!({ "kind": "Value", "value": 1 })
     );
+
+    let converted = ConvertedPayloadWrapper::Value(ConvertedScalar(1));
+    let converted = serde_json::to_value(converted).unwrap();
+    assert_eq!(
+        converted,
+        serde_json::json!({ "kind": "Value", "converted_value": 1 })
+    );
+    assert!(serde_json::from_value::<ConvertedPayloadWrapper>(converted).is_ok());
 }
 
 #[test]
@@ -539,6 +589,9 @@ fn format_accepts_newtype_unit_and_generic_payloads() {
     specta_serde::Format
         .map_types(&Types::default().register::<TransparentWithSkippedSiblingWrapper>())
         .expect("transparent tuple structs delegate through their sole live field");
+    specta_serde::Format
+        .map_types(&Types::default().register::<ConvertedPayloadWrapper>())
+        .expect("map-shaped conversion wires are valid internally tagged payloads");
     specta_serde::Format
         .map_types(&Types::default().register::<GenericPayload<Inner>>())
         .expect("generic payloads must be validated at their concrete use site");
@@ -916,8 +969,10 @@ fn specta_hidden_newtype_payloads_are_rejected() {
     for types in [
         Types::default().register::<HiddenNewtypePayload>(),
         Types::default().register::<DirectHiddenPayload>(),
+        Types::default().register::<DirectHiddenNamedPayload>(),
         Types::default().register::<HiddenNamedPayload>(),
         Types::default().register::<ExternalWithHiddenPayloadWrapper>(),
+        Types::default().register::<GenericPayload<HiddenNamed>>(),
     ] {
         assert!(
             specta_serde::Format.map_types(&types).is_err(),

--- a/tests/tests/serde_internal_tag_payloads.rs
+++ b/tests/tests/serde_internal_tag_payloads.rs
@@ -202,6 +202,40 @@ enum ExternalFlattenOnly {
 
 #[derive(Type, Serialize, Deserialize)]
 #[specta(collect = false)]
+enum ExternalWithContextualFlatten {
+    Unit,
+    Struct {
+        #[serde(flatten)]
+        inner: Inner,
+    },
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum ExternalWithContextualFlattenWrapper {
+    Value(ExternalWithContextualFlatten),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+enum ExternalWithContextualAlias {
+    Unit,
+    Struct {
+        #[serde(alias = "old_value")]
+        value: i32,
+    },
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum ExternalWithContextualAliasWrapper {
+    Value(ExternalWithContextualAlias),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
 #[serde(tag = "kind")]
 enum ExternalFlattenOnlyWrapper {
     Value(ExternalFlattenOnly),
@@ -667,6 +701,62 @@ fn exact_external_map_payload_bypasses_contextual_rebuilding() {
     specta_serde::Format
         .map_types(&Types::default().register::<ExternalFlattenOnlyWrapper>())
         .expect("an external enum with only map variants already has the contextual wire shape");
+}
+
+#[test]
+fn contextual_external_enum_lowers_flattened_and_aliased_fields() {
+    assert_eq!(
+        serde_json::to_value(ExternalWithContextualFlattenWrapper::Value(
+            ExternalWithContextualFlatten::Struct {
+                inner: Inner { value: 1 },
+            },
+        ))
+        .unwrap(),
+        serde_json::json!({ "kind": "Value", "Struct": { "value": 1 } })
+    );
+    assert!(matches!(
+        serde_json::from_value::<ExternalWithContextualAliasWrapper>(serde_json::json!({
+            "kind": "Value",
+            "Struct": { "old_value": 1 },
+        }))
+        .unwrap(),
+        ExternalWithContextualAliasWrapper::Value(ExternalWithContextualAlias::Struct { value: 1 })
+    ));
+
+    let flattened = specta_serde::PhasesFormat
+        .map_types(&Types::default().register::<ExternalWithContextualFlattenWrapper>())
+        .expect("a flattened map variant remains valid beside a contextual unit variant")
+        .into_owned();
+    let flattened = flattened
+        .into_unsorted_iter()
+        .find(|ndt| ndt.name == "ExternalWithContextualFlattenWrapper")
+        .and_then(|ndt| ndt.ty.as_ref())
+        .expect("mapped flattened wrapper definition should exist");
+    assert!(!contains_named_field(flattened, "inner", |_| true));
+
+    let aliased = specta_serde::PhasesFormat
+        .map_types(&Types::default().register::<ExternalWithContextualAliasWrapper>())
+        .expect("an aliased map variant remains valid beside a contextual unit variant")
+        .into_owned();
+    let aliased = aliased
+        .into_unsorted_iter()
+        .find(|ndt| ndt.name == "ExternalWithContextualAliasWrapper_Deserialize")
+        .and_then(|ndt| ndt.ty.as_ref())
+        .expect("mapped aliased deserialize wrapper definition should exist");
+    assert!(
+        contains_named_field(aliased, "value", |ty| matches!(
+            ty,
+            DataType::Primitive(specta::datatype::Primitive::i32)
+        )),
+        "aliased payload should accept `value`: {aliased:#?}"
+    );
+    assert!(
+        contains_named_field(aliased, "old_value", |ty| matches!(
+            ty,
+            DataType::Primitive(specta::datatype::Primitive::i32)
+        )),
+        "aliased payload should accept `old_value`: {aliased:#?}"
+    );
 }
 
 #[test]

--- a/tests/tests/serde_internal_tag_payloads.rs
+++ b/tests/tests/serde_internal_tag_payloads.rs
@@ -380,6 +380,14 @@ enum UntaggedAttributedMapPayload {
 
 #[derive(Type, Serialize, Deserialize)]
 #[specta(collect = false)]
+#[serde(untagged)]
+enum UntaggedSerializeImpossible {
+    #[serde(skip_serializing)]
+    Live { value: i32 },
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
 #[serde(tag = "kind")]
 enum UntaggedExternalPayloadWrapper {
     Value(UntaggedExternalPayload),
@@ -404,6 +412,13 @@ enum UntaggedMapPayloadWithSkippedScalarWrapper {
 #[serde(tag = "kind")]
 enum UntaggedAttributedMapPayloadWrapper {
     Value(UntaggedAttributedMapPayload),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum UntaggedSerializeImpossibleWrapper {
+    Value(UntaggedSerializeImpossible),
 }
 
 #[derive(Type, Serialize, Deserialize)]
@@ -1007,6 +1022,38 @@ fn nested_untagged_enum_propagates_contextual_external_shape() {
         assert!(!contains_named_field(wrapper, "value", |_| true));
         assert!(!contains_named_field(wrapper, "inner", |_| true));
     }
+
+    let mapped = specta_serde::PhasesFormat
+        .map_types(&Types::default().register::<UntaggedSerializeImpossibleWrapper>())
+        .expect("a phase with no live inner variants should map to an impossible payload")
+        .into_owned();
+    let serialize = mapped
+        .into_unsorted_iter()
+        .find(|ndt| ndt.name == "UntaggedSerializeImpossibleWrapper_Serialize")
+        .and_then(|ndt| ndt.ty.as_ref())
+        .expect("mapped impossible serialize wrapper should exist");
+    assert!(
+        contains_empty_enum(serialize),
+        "the outer serialize variant must be impossible: {serialize:#?}"
+    );
+    let deserialize = mapped
+        .into_unsorted_iter()
+        .find(|ndt| ndt.name == "UntaggedSerializeImpossibleWrapper_Deserialize")
+        .and_then(|ndt| ndt.ty.as_ref())
+        .expect("mapped live deserialize wrapper should exist");
+    let payload_reference = find_external_reference(deserialize)
+        .expect("deserialize wrapper should reference its live generated payload");
+    let payload = mapped
+        .get(payload_reference)
+        .and_then(|ndt| ndt.ty.as_ref())
+        .expect("referenced deserialize payload should exist");
+    assert!(
+        contains_named_field(payload, "value", |ty| matches!(
+            ty,
+            DataType::Primitive(specta::datatype::Primitive::i32)
+        )),
+        "the referenced deserialize map variant must remain live: {payload:#?}"
+    );
 }
 
 #[test]
@@ -1214,5 +1261,107 @@ fn contains_string_primitive(ty: &DataType) -> bool {
             contains_string_primitive(map.key_ty()) || contains_string_primitive(map.value_ty())
         }
         DataType::Primitive(_) | DataType::Reference(_) | DataType::Generic(_) => false,
+    }
+}
+
+fn contains_empty_enum(ty: &DataType) -> bool {
+    match ty {
+        DataType::Enum(enm) => {
+            enm.variants.is_empty()
+                || enm
+                    .variants
+                    .iter()
+                    .any(|(_, variant)| match &variant.fields {
+                        specta::datatype::Fields::Named(fields) => fields
+                            .fields
+                            .iter()
+                            .any(|(_, field)| field.ty.as_ref().is_some_and(contains_empty_enum)),
+                        specta::datatype::Fields::Unnamed(fields) => fields
+                            .fields
+                            .iter()
+                            .any(|field| field.ty.as_ref().is_some_and(contains_empty_enum)),
+                        specta::datatype::Fields::Unit => false,
+                    })
+        }
+        DataType::Struct(strct) => match &strct.fields {
+            specta::datatype::Fields::Named(fields) => fields
+                .fields
+                .iter()
+                .any(|(_, field)| field.ty.as_ref().is_some_and(contains_empty_enum)),
+            specta::datatype::Fields::Unnamed(fields) => fields
+                .fields
+                .iter()
+                .any(|field| field.ty.as_ref().is_some_and(contains_empty_enum)),
+            specta::datatype::Fields::Unit => false,
+        },
+        DataType::Intersection(parts)
+        | DataType::Tuple(specta::datatype::Tuple {
+            elements: parts, ..
+        }) => parts.iter().any(contains_empty_enum),
+        DataType::Nullable(ty) => contains_empty_enum(ty),
+        DataType::List(list) => contains_empty_enum(&list.ty),
+        DataType::Map(map) => {
+            contains_empty_enum(map.key_ty()) || contains_empty_enum(map.value_ty())
+        }
+        DataType::Reference(specta::datatype::Reference::Named(reference)) => {
+            match &reference.inner {
+                specta::datatype::NamedReferenceType::Inline { dt, .. } => contains_empty_enum(dt),
+                specta::datatype::NamedReferenceType::Reference { .. }
+                | specta::datatype::NamedReferenceType::Recursive(_) => false,
+            }
+        }
+        DataType::Primitive(_)
+        | DataType::Reference(specta::datatype::Reference::Opaque(_))
+        | DataType::Generic(_) => false,
+    }
+}
+
+fn find_external_reference(ty: &DataType) -> Option<&specta::datatype::NamedReference> {
+    match ty {
+        DataType::Reference(specta::datatype::Reference::Named(reference)) => {
+            match &reference.inner {
+                specta::datatype::NamedReferenceType::Reference { .. }
+                | specta::datatype::NamedReferenceType::Recursive(_) => Some(reference),
+                specta::datatype::NamedReferenceType::Inline { dt, .. } => {
+                    find_external_reference(dt)
+                }
+            }
+        }
+        DataType::Struct(strct) => match &strct.fields {
+            specta::datatype::Fields::Named(fields) => fields
+                .fields
+                .iter()
+                .find_map(|(_, field)| field.ty.as_ref().and_then(find_external_reference)),
+            specta::datatype::Fields::Unnamed(fields) => fields
+                .fields
+                .iter()
+                .find_map(|field| field.ty.as_ref().and_then(find_external_reference)),
+            specta::datatype::Fields::Unit => None,
+        },
+        DataType::Enum(enm) => enm
+            .variants
+            .iter()
+            .find_map(|(_, variant)| match &variant.fields {
+                specta::datatype::Fields::Named(fields) => fields
+                    .fields
+                    .iter()
+                    .find_map(|(_, field)| field.ty.as_ref().and_then(find_external_reference)),
+                specta::datatype::Fields::Unnamed(fields) => fields
+                    .fields
+                    .iter()
+                    .find_map(|field| field.ty.as_ref().and_then(find_external_reference)),
+                specta::datatype::Fields::Unit => None,
+            }),
+        DataType::Intersection(parts)
+        | DataType::Tuple(specta::datatype::Tuple {
+            elements: parts, ..
+        }) => parts.iter().find_map(find_external_reference),
+        DataType::Nullable(ty) => find_external_reference(ty),
+        DataType::List(list) => find_external_reference(&list.ty),
+        DataType::Map(map) => find_external_reference(map.key_ty())
+            .or_else(|| find_external_reference(map.value_ty())),
+        DataType::Primitive(_)
+        | DataType::Reference(specta::datatype::Reference::Opaque(_))
+        | DataType::Generic(_) => None,
     }
 }

--- a/tests/tests/serde_internal_tag_payloads.rs
+++ b/tests/tests/serde_internal_tag_payloads.rs
@@ -1,0 +1,856 @@
+// Regression tests for internally tagged newtype variants. Serde routes their
+// payload through `TaggedSerializer`, whose accepted shapes and enum encoding
+// differ from the payload's standalone representation.
+
+use serde::{Deserialize, Serialize};
+use specta::{Format as _, Type, Types, datatype::DataType};
+
+#[derive(Debug, PartialEq, Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+struct Inner {
+    value: i32,
+}
+
+#[derive(Debug, PartialEq, Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+struct Newtype(Inner);
+
+#[derive(Debug, PartialEq, Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+struct Unit;
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+struct HiddenNewtype(#[specta(skip)] i32);
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+struct HiddenNamed {
+    #[specta(skip)]
+    value: i32,
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+struct HiddenNamedNewtype(HiddenNamed);
+
+#[derive(Debug, PartialEq, Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum NewtypePayloads {
+    Newtype(Newtype),
+    Unit(Unit),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum HiddenNewtypePayload {
+    Value(HiddenNewtype),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum DirectHiddenPayload {
+    Value(#[specta(skip)] i32),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum HiddenNamedPayload {
+    Value(HiddenNamedNewtype),
+}
+
+#[derive(Debug, PartialEq, Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum GenericPayload<T> {
+    Value(T),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum WrappedGenericPayload<T> {
+    Value(GenericNewtype<T>),
+}
+
+#[derive(Debug, PartialEq, Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+enum ExternalPayload {
+    Unit,
+    Newtype(i32),
+    Tuple(i32, i32),
+    Struct { value: i32 },
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+enum ExternalWithoutUnit {
+    Newtype(i32),
+    Tuple(i32, i32),
+    Struct { value: i32 },
+}
+
+#[derive(Debug, PartialEq, Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum ExternalPayloadWrapper {
+    Value(ExternalPayload),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+enum GenericExternalPayload<T> {
+    Unit,
+    Newtype(T),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum ConcreteExternalPayloadWrapper {
+    Value(GenericExternalPayload<i32>),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum InlineGenericExternalPayloadWrapper {
+    Value(#[specta(inline)] GenericExternalPayload<i32>),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+struct GenericNewtype<T>(T);
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum GenericNewtypeExternalWrapper {
+    Value(GenericNewtype<ExternalPayload>),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum NestedGenericNewtypeExternalWrapper {
+    Value(GenericNewtype<GenericNewtype<ExternalPayload>>),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+enum ExternalWithSerdeAttrs {
+    Renamed {
+        #[serde(rename = "wire_value")]
+        value: i32,
+    },
+    Skipped(#[serde(skip)] i32),
+    #[serde(untagged)]
+    Raw {
+        raw_value: i32,
+    },
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum ExternalWithSerdeAttrsWrapper {
+    Value(ExternalWithSerdeAttrs),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+enum ExternalWithSkippedFlatten {
+    #[serde(skip)]
+    Dead {
+        #[serde(flatten)]
+        inner: Inner,
+    },
+    Live {
+        value: i32,
+    },
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum ExternalWithSkippedFlattenWrapper {
+    Value(ExternalWithSkippedFlatten),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+enum ExternalFlattenOnly {
+    Struct {
+        #[serde(flatten)]
+        inner: Inner,
+    },
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum ExternalFlattenOnlyWrapper {
+    Value(ExternalFlattenOnly),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+enum ExternalWithHiddenPayload {
+    Value(#[specta(skip)] i32),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum ExternalWithHiddenPayloadWrapper {
+    Value(ExternalWithHiddenPayload),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum InlineExternalPayloadWrapper {
+    Value(#[specta(inline)] ExternalPayload),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+enum ExternalWithUntaggedUnitInline {
+    Known {
+        value: i32,
+    },
+    #[serde(untagged)]
+    Unit,
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum InlineExternalWithUntaggedUnitWrapper {
+    Value(#[specta(inline)] ExternalWithUntaggedUnitInline),
+}
+
+#[derive(Type, Serialize)]
+#[specta(collect = false)]
+enum ExternalWithInvalidUntagged {
+    #[serde(untagged)]
+    Scalar(i32),
+}
+
+#[derive(Type, Serialize)]
+#[specta(collect = false)]
+enum ExternalWithUntaggedUnit {
+    #[serde(untagged)]
+    Unit,
+}
+
+#[derive(Type, Serialize)]
+#[specta(collect = false)]
+enum ExternalWithUntaggedEmptyStruct {
+    #[serde(untagged)]
+    Empty {},
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(untagged)]
+enum UntaggedExternalPayload {
+    External(ExternalPayload),
+    Struct { raw: i32 },
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum UntaggedExternalPayloadWrapper {
+    Value(UntaggedExternalPayload),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+enum ExternalWithOther {
+    Known,
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum InlineExternalWithOtherWrapper {
+    Value(#[specta(inline)] ExternalWithOther),
+}
+
+#[derive(Type, Serialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum InvalidUntaggedExternalWrapper {
+    Value(ExternalWithInvalidUntagged),
+}
+
+#[derive(Type, Serialize)]
+#[specta(collect = false)]
+struct InvalidTuple(i32, i32);
+
+#[derive(Type, Serialize)]
+#[specta(collect = false)]
+struct InvalidEmptyTuple();
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false, transparent = false)]
+#[serde(transparent)]
+struct TransparentWithSkippedSibling(Inner, #[serde(skip)] u8);
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false, transparent = false)]
+#[serde(transparent)]
+struct NamedTransparentUnit {
+    inner: Unit,
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false, transparent = false)]
+#[serde(transparent)]
+struct NamedTransparentExternal {
+    inner: ExternalPayload,
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum TransparentWithSkippedSiblingWrapper {
+    Value(TransparentWithSkippedSibling),
+}
+
+#[derive(Type, Serialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum InvalidTuplePayloads {
+    Tuple(InvalidTuple),
+    Empty(InvalidEmptyTuple),
+}
+
+#[test]
+fn serde_accepts_newtype_and_unit_struct_payloads() {
+    let newtype = NewtypePayloads::Newtype(Newtype(Inner { value: 1 }));
+    assert_eq!(
+        serde_json::to_value(&newtype).unwrap(),
+        serde_json::json!({ "kind": "Newtype", "value": 1 })
+    );
+    assert_eq!(
+        serde_json::from_value::<NewtypePayloads>(serde_json::to_value(&newtype).unwrap()).unwrap(),
+        newtype
+    );
+
+    let unit = NewtypePayloads::Unit(Unit);
+    assert_eq!(
+        serde_json::to_value(&unit).unwrap(),
+        serde_json::json!({ "kind": "Unit" })
+    );
+    assert_eq!(
+        serde_json::from_value::<NewtypePayloads>(serde_json::to_value(&unit).unwrap()).unwrap(),
+        unit
+    );
+
+    assert_eq!(
+        serde_json::to_value(TransparentWithSkippedSiblingWrapper::Value(
+            TransparentWithSkippedSibling(Inner { value: 1 }, 0)
+        ))
+        .unwrap(),
+        serde_json::json!({ "kind": "Value", "value": 1 })
+    );
+}
+
+#[test]
+fn format_accepts_newtype_unit_and_generic_payloads() {
+    specta_serde::Format
+        .map_types(&Types::default().register::<NewtypePayloads>())
+        .expect("newtype and unit structs are valid internally tagged payloads");
+    specta_serde::Format
+        .map_types(&Types::default().register::<TransparentWithSkippedSiblingWrapper>())
+        .expect("transparent tuple structs delegate through their sole live field");
+    specta_serde::Format
+        .map_types(&Types::default().register::<GenericPayload<Inner>>())
+        .expect("generic payloads must be validated at their concrete use site");
+    specta_serde::Format
+        .map_types(&Types::default().register::<GenericPayload<ExternalWithoutUnit>>())
+        .expect("external payloads without unit-like variants need no contextual rewrite");
+    specta_serde::Format
+        .map_types(&Types::default().register::<GenericPayload<ExternalWithUntaggedEmptyStruct>>())
+        .expect("an untagged empty object already merges with an internal tag correctly");
+
+    let err = specta_serde::Format
+        .map_types(&Types::default().register::<GenericPayload<i32>>())
+        .expect_err("a concrete scalar generic payload is invalid for TaggedSerializer");
+    assert!(
+        err.to_string().contains("payload cannot be merged"),
+        "unexpected error: {err}"
+    );
+
+    for types in [
+        Types::default().register::<GenericPayload<Unit>>(),
+        Types::default().register::<GenericPayload<()>>(),
+        Types::default().register::<GenericPayload<NamedTransparentUnit>>(),
+        Types::default().register::<GenericPayload<NamedTransparentExternal>>(),
+    ] {
+        let err = specta_serde::Format
+            .map_types(&types)
+            .expect_err("a standalone null-like generic argument cannot be intersected with a tag");
+        assert!(
+            err.to_string().contains("context-sensitive enum encoding"),
+            "unexpected error: {err}"
+        );
+    }
+
+    let err = specta_serde::Format
+        .map_types(&Types::default().register::<GenericPayload<ExternalPayload>>())
+        .expect_err("a generic definition cannot contextually re-encode a concrete enum argument");
+    assert!(
+        err.to_string().contains("context-sensitive enum encoding"),
+        "unexpected error: {err}"
+    );
+
+    let err = specta_serde::Format
+        .map_types(&Types::default().register::<WrappedGenericPayload<ExternalPayload>>())
+        .expect_err("a generic wrapper must not hide context-sensitive enum encoding");
+    assert!(
+        err.to_string().contains("context-sensitive enum encoding"),
+        "unexpected error: {err}"
+    );
+
+    let err = specta_serde::Format
+        .map_types(&Types::default().register::<GenericPayload<ExternalWithUntaggedUnit>>())
+        .expect_err("an untagged unit contributes no payload under TaggedSerializer");
+    assert!(
+        err.to_string().contains("context-sensitive enum encoding"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn tagged_serializer_uses_map_encoding_for_external_enums() {
+    let cases = [
+        (
+            ExternalPayloadWrapper::Value(ExternalPayload::Unit),
+            serde_json::json!({ "kind": "Value", "Unit": null }),
+        ),
+        (
+            ExternalPayloadWrapper::Value(ExternalPayload::Newtype(1)),
+            serde_json::json!({ "kind": "Value", "Newtype": 1 }),
+        ),
+        (
+            ExternalPayloadWrapper::Value(ExternalPayload::Tuple(1, 2)),
+            serde_json::json!({ "kind": "Value", "Tuple": [1, 2] }),
+        ),
+        (
+            ExternalPayloadWrapper::Value(ExternalPayload::Struct { value: 1 }),
+            serde_json::json!({ "kind": "Value", "Struct": { "value": 1 } }),
+        ),
+    ];
+
+    for (value, expected) in cases {
+        assert_eq!(serde_json::to_value(&value).unwrap(), expected);
+        assert_eq!(
+            serde_json::from_value::<ExternalPayloadWrapper>(expected).unwrap(),
+            value
+        );
+    }
+}
+
+#[test]
+fn format_inlines_external_enum_tagged_serializer_shape() {
+    let types = Types::default().register::<ExternalPayloadWrapper>();
+    let mapped = specta_serde::Format
+        .map_types(&types)
+        .expect("external enum payload is supported by TaggedSerializer")
+        .into_owned();
+    let wrapper = mapped
+        .into_unsorted_iter()
+        .find(|ndt| ndt.name == "ExternalPayloadWrapper")
+        .and_then(|ndt| ndt.ty.as_ref())
+        .expect("mapped wrapper definition should exist");
+
+    assert!(
+        contains_named_field(wrapper, "Unit", |ty| {
+            matches!(ty, DataType::Tuple(tuple) if tuple.elements.is_empty())
+        }),
+        "the contextual external unit variant must become `Unit: null`: {wrapper:#?}"
+    );
+    assert!(
+        contains_named_field(wrapper, "Tuple", |ty| {
+            matches!(ty, DataType::Tuple(tuple) if tuple.elements.len() == 2)
+        }),
+        "tuple variants remain map entries with tuple values: {wrapper:#?}"
+    );
+}
+
+#[test]
+fn contextual_external_enum_shape_substitutes_concrete_generics() {
+    for (name, types) in [
+        (
+            "ConcreteExternalPayloadWrapper",
+            Types::default().register::<ConcreteExternalPayloadWrapper>(),
+        ),
+        (
+            "InlineGenericExternalPayloadWrapper",
+            Types::default().register::<InlineGenericExternalPayloadWrapper>(),
+        ),
+    ] {
+        let mapped = specta_serde::Format
+            .map_types(&types)
+            .expect("concrete generic external payload should remain concrete")
+            .into_owned();
+        let wrapper = mapped
+            .into_unsorted_iter()
+            .find(|ndt| ndt.name == name)
+            .and_then(|ndt| ndt.ty.as_ref())
+            .expect("mapped wrapper definition should exist");
+
+        assert!(
+            contains_named_field(wrapper, "Newtype", |ty| {
+                matches!(ty, DataType::Primitive(specta::datatype::Primitive::i32))
+            }),
+            "the concrete generic argument must replace the inner placeholder: {wrapper:#?}"
+        );
+    }
+}
+
+#[test]
+fn generic_newtype_wrapper_does_not_hide_external_enum_shape() {
+    for (name, types) in [
+        (
+            "GenericNewtypeExternalWrapper",
+            Types::default().register::<GenericNewtypeExternalWrapper>(),
+        ),
+        (
+            "NestedGenericNewtypeExternalWrapper",
+            Types::default().register::<NestedGenericNewtypeExternalWrapper>(),
+        ),
+    ] {
+        let mapped = specta_serde::Format
+            .map_types(&types)
+            .expect("generic newtype wrappers delegate into TaggedSerializer")
+            .into_owned();
+        let wrapper = mapped
+            .into_unsorted_iter()
+            .find(|ndt| ndt.name == name)
+            .and_then(|ndt| ndt.ty.as_ref())
+            .expect("mapped wrapper definition should exist");
+
+        assert!(
+            contains_named_field(wrapper, "Unit", |ty| {
+                matches!(ty, DataType::Tuple(tuple) if tuple.elements.is_empty())
+            }),
+            "the wrapper must expose the contextual `Unit: null` entry: {wrapper:#?}"
+        );
+    }
+}
+
+#[test]
+fn contextual_external_enum_applies_serde_field_and_variant_semantics() {
+    assert_eq!(
+        serde_json::to_value(ExternalWithSerdeAttrsWrapper::Value(
+            ExternalWithSerdeAttrs::Renamed { value: 1 }
+        ))
+        .unwrap(),
+        serde_json::json!({ "kind": "Value", "Renamed": { "wire_value": 1 } })
+    );
+    assert_eq!(
+        serde_json::to_value(ExternalWithSerdeAttrsWrapper::Value(
+            ExternalWithSerdeAttrs::Skipped(1)
+        ))
+        .unwrap(),
+        serde_json::json!({ "kind": "Value", "Skipped": null })
+    );
+    assert_eq!(
+        serde_json::to_value(ExternalWithSerdeAttrsWrapper::Value(
+            ExternalWithSerdeAttrs::Raw { raw_value: 1 }
+        ))
+        .unwrap(),
+        serde_json::json!({ "kind": "Value", "raw_value": 1 })
+    );
+
+    let types = Types::default().register::<ExternalWithSerdeAttrsWrapper>();
+    let mapped = specta_serde::Format
+        .map_types(&types)
+        .expect("contextual lowering should apply serde field and variant attributes")
+        .into_owned();
+    let wrapper = mapped
+        .into_unsorted_iter()
+        .find(|ndt| ndt.name == "ExternalWithSerdeAttrsWrapper")
+        .and_then(|ndt| ndt.ty.as_ref())
+        .expect("mapped wrapper definition should exist");
+
+    assert!(contains_named_field(wrapper, "wire_value", |ty| matches!(
+        ty,
+        DataType::Primitive(specta::datatype::Primitive::i32)
+    )));
+    assert!(contains_named_field(wrapper, "Skipped", |ty| matches!(
+        ty,
+        DataType::Tuple(tuple) if tuple.elements.is_empty()
+    )));
+    assert!(contains_named_field(wrapper, "raw_value", |ty| matches!(
+        ty,
+        DataType::Primitive(specta::datatype::Primitive::i32)
+    )));
+}
+
+#[test]
+fn skipped_variant_does_not_trigger_contextual_flatten_error() {
+    let types = Types::default().register::<ExternalWithSkippedFlattenWrapper>();
+    let mapped = specta_serde::Format
+        .map_types(&types)
+        .expect("attributes on skipped variants are not part of the wire shape")
+        .into_owned();
+    let mapped = mapped.into_unsorted_iter().collect::<Vec<_>>();
+    let payload = mapped
+        .iter()
+        .find(|ndt| ndt.name == "ExternalWithSkippedFlatten")
+        .and_then(|ndt| ndt.ty.as_ref())
+        .expect("mapped payload definition should exist");
+
+    assert!(contains_named_field(payload, "value", |ty| matches!(
+        ty,
+        DataType::Primitive(specta::datatype::Primitive::i32)
+    )));
+    assert!(!contains_named_field(payload, "Dead", |_| true));
+}
+
+#[test]
+fn exact_external_map_payload_bypasses_contextual_rebuilding() {
+    assert_eq!(
+        serde_json::to_value(ExternalFlattenOnlyWrapper::Value(
+            ExternalFlattenOnly::Struct {
+                inner: Inner { value: 1 },
+            }
+        ))
+        .unwrap(),
+        serde_json::json!({ "kind": "Value", "Struct": { "value": 1 } })
+    );
+    specta_serde::Format
+        .map_types(&Types::default().register::<ExternalFlattenOnlyWrapper>())
+        .expect("an external enum with only map variants already has the contextual wire shape");
+}
+
+#[test]
+fn specta_hidden_newtype_payloads_are_rejected() {
+    for types in [
+        Types::default().register::<HiddenNewtypePayload>(),
+        Types::default().register::<DirectHiddenPayload>(),
+        Types::default().register::<HiddenNamedPayload>(),
+        Types::default().register::<ExternalWithHiddenPayloadWrapper>(),
+    ] {
+        assert!(
+            specta_serde::Format.map_types(&types).is_err(),
+            "serde still transports the payload hidden from Specta, so its shape is unknown"
+        );
+    }
+}
+
+#[test]
+fn inline_external_enum_keeps_tagged_serializer_shape() {
+    let types = Types::default().register::<InlineExternalPayloadWrapper>();
+    let mapped = specta_serde::Format
+        .map_types(&types)
+        .expect("inline external enums use the same contextual representation")
+        .into_owned();
+    let wrapper = mapped
+        .into_unsorted_iter()
+        .find(|ndt| ndt.name == "InlineExternalPayloadWrapper")
+        .and_then(|ndt| ndt.ty.as_ref())
+        .expect("mapped wrapper definition should exist");
+
+    assert!(contains_named_field(wrapper, "Unit", |ty| matches!(
+        ty,
+        DataType::Tuple(tuple) if tuple.elements.is_empty()
+    )));
+}
+
+#[test]
+fn inline_external_untagged_unit_contributes_an_empty_object() {
+    assert_eq!(
+        serde_json::to_value(InlineExternalWithUntaggedUnitWrapper::Value(
+            ExternalWithUntaggedUnitInline::Unit
+        ))
+        .unwrap(),
+        serde_json::json!({ "kind": "Value" })
+    );
+
+    let mapped = specta_serde::Format
+        .map_types(&Types::default().register::<InlineExternalWithUntaggedUnitWrapper>())
+        .expect("an untagged unit contributes no fields under TaggedSerializer")
+        .into_owned();
+    let wrapper = mapped
+        .into_unsorted_iter()
+        .find(|ndt| ndt.name == "InlineExternalWithUntaggedUnitWrapper")
+        .and_then(|ndt| ndt.ty.as_ref())
+        .expect("mapped wrapper definition should exist");
+
+    assert!(contains_empty_object(wrapper));
+}
+
+#[test]
+fn nested_untagged_enum_propagates_contextual_external_shape() {
+    let mapped = specta_serde::Format
+        .map_types(&Types::default().register::<UntaggedExternalPayloadWrapper>())
+        .expect("nested untagged payloads propagate contextual replacements")
+        .into_owned();
+    let wrapper = mapped
+        .into_unsorted_iter()
+        .find(|ndt| ndt.name == "UntaggedExternalPayloadWrapper")
+        .and_then(|ndt| ndt.ty.as_ref())
+        .expect("mapped wrapper definition should exist");
+
+    assert!(contains_named_field(wrapper, "Unit", |ty| matches!(
+        ty,
+        DataType::Tuple(tuple) if tuple.elements.is_empty()
+    )));
+}
+
+#[test]
+fn inline_external_other_is_rejected_in_contextual_deserialize_shape() {
+    assert!(
+        specta_serde::PhasesFormat
+            .map_types(&Types::default().register::<InlineExternalWithOtherWrapper>())
+            .is_err(),
+        "a widened unknown map key cannot be represented without constraining the outer tag"
+    );
+}
+
+#[test]
+fn contextual_untagged_scalar_payload_is_rejected() {
+    assert!(
+        serde_json::to_value(InvalidUntaggedExternalWrapper::Value(
+            ExternalWithInvalidUntagged::Scalar(1)
+        ))
+        .is_err()
+    );
+
+    let err = specta_serde::Format
+        .map_types(&Types::default().register::<InvalidUntaggedExternalWrapper>())
+        .expect_err("TaggedSerializer rejects scalar untagged payloads");
+    assert!(
+        err.to_string().contains("cannot be merged"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn direct_tuple_struct_payloads_remain_invalid() {
+    assert!(serde_json::to_value(InvalidTuplePayloads::Tuple(InvalidTuple(1, 2))).is_err());
+    assert!(serde_json::to_value(InvalidTuplePayloads::Empty(InvalidEmptyTuple())).is_err());
+
+    let err = specta_serde::Format
+        .map_types(&Types::default().register::<InvalidTuplePayloads>())
+        .expect_err("TaggedSerializer rejects tuple struct payloads");
+    assert!(
+        err.to_string().contains("payload cannot be merged"),
+        "unexpected error: {err}"
+    );
+}
+
+fn contains_named_field(
+    ty: &DataType,
+    expected_name: &str,
+    expected_ty: impl Copy + Fn(&DataType) -> bool,
+) -> bool {
+    match ty {
+        DataType::Struct(strct) => match &strct.fields {
+            specta::datatype::Fields::Named(fields) => fields.fields.iter().any(|(name, field)| {
+                (name == expected_name && field.ty.as_ref().is_some_and(expected_ty))
+                    || field
+                        .ty
+                        .as_ref()
+                        .is_some_and(|ty| contains_named_field(ty, expected_name, expected_ty))
+            }),
+            specta::datatype::Fields::Unnamed(fields) => fields.fields.iter().any(|field| {
+                field
+                    .ty
+                    .as_ref()
+                    .is_some_and(|ty| contains_named_field(ty, expected_name, expected_ty))
+            }),
+            specta::datatype::Fields::Unit => false,
+        },
+        DataType::Enum(enm) => enm
+            .variants
+            .iter()
+            .any(|(_, variant)| match &variant.fields {
+                specta::datatype::Fields::Named(fields) => {
+                    fields.fields.iter().any(|(name, field)| {
+                        (name == expected_name && field.ty.as_ref().is_some_and(expected_ty))
+                            || field.ty.as_ref().is_some_and(|ty| {
+                                contains_named_field(ty, expected_name, expected_ty)
+                            })
+                    })
+                }
+                specta::datatype::Fields::Unnamed(fields) => fields.fields.iter().any(|field| {
+                    field
+                        .ty
+                        .as_ref()
+                        .is_some_and(|ty| contains_named_field(ty, expected_name, expected_ty))
+                }),
+                specta::datatype::Fields::Unit => false,
+            }),
+        DataType::Intersection(parts) => parts
+            .iter()
+            .any(|ty| contains_named_field(ty, expected_name, expected_ty)),
+        DataType::Nullable(ty) => contains_named_field(ty, expected_name, expected_ty),
+        DataType::Tuple(tuple) => tuple
+            .elements
+            .iter()
+            .any(|ty| contains_named_field(ty, expected_name, expected_ty)),
+        DataType::List(list) => contains_named_field(&list.ty, expected_name, expected_ty),
+        DataType::Map(map) => {
+            contains_named_field(map.key_ty(), expected_name, expected_ty)
+                || contains_named_field(map.value_ty(), expected_name, expected_ty)
+        }
+        DataType::Primitive(_) | DataType::Reference(_) | DataType::Generic(_) => false,
+    }
+}
+
+fn contains_empty_object(ty: &DataType) -> bool {
+    match ty {
+        DataType::Struct(strct) => match &strct.fields {
+            specta::datatype::Fields::Named(fields) => {
+                fields.fields.is_empty()
+                    || fields
+                        .fields
+                        .iter()
+                        .any(|(_, field)| field.ty.as_ref().is_some_and(contains_empty_object))
+            }
+            specta::datatype::Fields::Unnamed(fields) => fields
+                .fields
+                .iter()
+                .any(|field| field.ty.as_ref().is_some_and(contains_empty_object)),
+            specta::datatype::Fields::Unit => false,
+        },
+        DataType::Enum(enm) => enm
+            .variants
+            .iter()
+            .any(|(_, variant)| match &variant.fields {
+                specta::datatype::Fields::Named(fields) => fields
+                    .fields
+                    .iter()
+                    .any(|(_, field)| field.ty.as_ref().is_some_and(contains_empty_object)),
+                specta::datatype::Fields::Unnamed(fields) => fields
+                    .fields
+                    .iter()
+                    .any(|field| field.ty.as_ref().is_some_and(contains_empty_object)),
+                specta::datatype::Fields::Unit => false,
+            }),
+        DataType::Intersection(parts)
+        | DataType::Tuple(specta::datatype::Tuple {
+            elements: parts, ..
+        }) => parts.iter().any(contains_empty_object),
+        DataType::Nullable(ty) => contains_empty_object(ty),
+        DataType::List(list) => contains_empty_object(&list.ty),
+        DataType::Map(map) => {
+            contains_empty_object(map.key_ty()) || contains_empty_object(map.value_ty())
+        }
+        DataType::Primitive(_) | DataType::Reference(_) | DataType::Generic(_) => false,
+    }
+}

--- a/tests/tests/serde_internal_tag_payloads.rs
+++ b/tests/tests/serde_internal_tag_payloads.rs
@@ -229,6 +229,30 @@ enum ExternalPartiallyHiddenTuplePayloadWrapper {
     Value(ExternalPartiallyHiddenTuplePayload),
 }
 
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+enum ExternalHiddenNamedVariantPayload {
+    Struct {
+        #[specta(skip)]
+        secret: i32,
+        visible: i32,
+    },
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum ExternalHiddenNamedVariantPayloadWrapper {
+    Value(ExternalHiddenNamedVariantPayload),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum InlineExternalHiddenNamedVariantPayloadWrapper {
+    Value(#[specta(inline)] ExternalHiddenNamedVariantPayload),
+}
+
 #[derive(Debug, PartialEq, Type, Serialize, Deserialize)]
 #[specta(collect = false)]
 #[serde(tag = "kind")]
@@ -1121,7 +1145,11 @@ fn specta_hidden_newtype_payloads_are_rejected() {
         Types::default().register::<InlineExternalUntaggedHiddenPayloadWrapper>(),
         Types::default().register::<ExternalHiddenTuplePayloadWrapper>(),
         Types::default().register::<ExternalPartiallyHiddenTuplePayloadWrapper>(),
+        Types::default().register::<ExternalHiddenNamedVariantPayloadWrapper>(),
+        Types::default().register::<InlineExternalHiddenNamedVariantPayloadWrapper>(),
         Types::default().register::<GenericPayload<HiddenNamed>>(),
+        Types::default().register::<GenericPayload<ExternalPartiallyHiddenTuplePayload>>(),
+        Types::default().register::<GenericPayload<ExternalHiddenNamedVariantPayload>>(),
     ] {
         assert!(
             specta_serde::Format.map_types(&types).is_err(),

--- a/tests/tests/serde_internal_tag_payloads.rs
+++ b/tests/tests/serde_internal_tag_payloads.rs
@@ -323,9 +323,43 @@ enum UntaggedExternalPayload {
 
 #[derive(Type, Serialize, Deserialize)]
 #[specta(collect = false)]
+#[serde(untagged)]
+enum UntaggedExternalPayloadWithSkippedScalar {
+    #[serde(skip)]
+    Dead(i32),
+    External(ExternalPayload),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(untagged)]
+enum UntaggedMapPayloadWithSkippedScalar {
+    #[serde(skip)]
+    Dead(String),
+    Live {
+        value: i32,
+    },
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
 #[serde(tag = "kind")]
 enum UntaggedExternalPayloadWrapper {
     Value(UntaggedExternalPayload),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum UntaggedExternalPayloadWithSkippedScalarWrapper {
+    Value(UntaggedExternalPayloadWithSkippedScalar),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum UntaggedMapPayloadWithSkippedScalarWrapper {
+    Value(UntaggedMapPayloadWithSkippedScalar),
 }
 
 #[derive(Type, Serialize, Deserialize)]
@@ -846,6 +880,38 @@ fn nested_untagged_enum_propagates_contextual_external_shape() {
         ty,
         DataType::Tuple(tuple) if tuple.elements.is_empty()
     )));
+
+    let mapped = specta_serde::Format
+        .map_types(&Types::default().register::<UntaggedExternalPayloadWithSkippedScalarWrapper>())
+        .expect("skipped untagged variants must not participate in contextual replacement")
+        .into_owned();
+    let wrapper = mapped
+        .into_unsorted_iter()
+        .find(|ndt| ndt.name == "UntaggedExternalPayloadWithSkippedScalarWrapper")
+        .and_then(|ndt| ndt.ty.as_ref())
+        .expect("mapped skipped-variant wrapper definition should exist");
+    assert!(contains_named_field(wrapper, "Unit", |ty| matches!(
+        ty,
+        DataType::Tuple(tuple) if tuple.elements.is_empty()
+    )));
+
+    let mapped = specta_serde::Format
+        .map_types(&Types::default().register::<UntaggedMapPayloadWithSkippedScalarWrapper>())
+        .expect("filtering a skipped branch must itself produce a contextual replacement")
+        .into_owned();
+    let wrapper = mapped
+        .into_unsorted_iter()
+        .find(|ndt| ndt.name == "UntaggedMapPayloadWithSkippedScalarWrapper")
+        .and_then(|ndt| ndt.ty.as_ref())
+        .expect("mapped map-only wrapper definition should exist");
+    assert!(contains_named_field(wrapper, "value", |ty| matches!(
+        ty,
+        DataType::Primitive(specta::datatype::Primitive::i32)
+    )));
+    assert!(
+        !contains_string_primitive(wrapper),
+        "the skipped scalar branch must not leak into the replacement: {wrapper:#?}"
+    );
 }
 
 #[test]
@@ -999,6 +1065,47 @@ fn contains_empty_object(ty: &DataType) -> bool {
         DataType::List(list) => contains_empty_object(&list.ty),
         DataType::Map(map) => {
             contains_empty_object(map.key_ty()) || contains_empty_object(map.value_ty())
+        }
+        DataType::Primitive(_) | DataType::Reference(_) | DataType::Generic(_) => false,
+    }
+}
+
+fn contains_string_primitive(ty: &DataType) -> bool {
+    match ty {
+        DataType::Primitive(specta::datatype::Primitive::str) => true,
+        DataType::Struct(strct) => match &strct.fields {
+            specta::datatype::Fields::Named(fields) => fields
+                .fields
+                .iter()
+                .any(|(_, field)| field.ty.as_ref().is_some_and(contains_string_primitive)),
+            specta::datatype::Fields::Unnamed(fields) => fields
+                .fields
+                .iter()
+                .any(|field| field.ty.as_ref().is_some_and(contains_string_primitive)),
+            specta::datatype::Fields::Unit => false,
+        },
+        DataType::Enum(enm) => enm
+            .variants
+            .iter()
+            .any(|(_, variant)| match &variant.fields {
+                specta::datatype::Fields::Named(fields) => fields
+                    .fields
+                    .iter()
+                    .any(|(_, field)| field.ty.as_ref().is_some_and(contains_string_primitive)),
+                specta::datatype::Fields::Unnamed(fields) => fields
+                    .fields
+                    .iter()
+                    .any(|field| field.ty.as_ref().is_some_and(contains_string_primitive)),
+                specta::datatype::Fields::Unit => false,
+            }),
+        DataType::Intersection(parts)
+        | DataType::Tuple(specta::datatype::Tuple {
+            elements: parts, ..
+        }) => parts.iter().any(contains_string_primitive),
+        DataType::Nullable(ty) => contains_string_primitive(ty),
+        DataType::List(list) => contains_string_primitive(&list.ty),
+        DataType::Map(map) => {
+            contains_string_primitive(map.key_ty()) || contains_string_primitive(map.value_ty())
         }
         DataType::Primitive(_) | DataType::Reference(_) | DataType::Generic(_) => false,
     }

--- a/tests/tests/serde_internal_tag_payloads.rs
+++ b/tests/tests/serde_internal_tag_payloads.rs
@@ -145,6 +145,13 @@ enum ConcreteExternalPayloadWrapper {
 #[derive(Type, Serialize, Deserialize)]
 #[specta(collect = false)]
 #[serde(tag = "kind")]
+enum GenericOptionExternalPayloadWrapper<T> {
+    Value(GenericExternalPayload<Option<T>>),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
 enum InlineGenericExternalPayloadWrapper {
     Value(#[specta(inline)] GenericExternalPayload<i32>),
 }
@@ -699,6 +706,23 @@ fn contextual_external_enum_shape_substitutes_concrete_generics() {
             "the concrete generic argument must replace the inner placeholder: {wrapper:#?}"
         );
     }
+
+    let mapped = specta_serde::Format
+        .map_types(&Types::default().register::<GenericOptionExternalPayloadWrapper<i32>>())
+        .expect("contextual generic substitution should be applied exactly once")
+        .into_owned();
+    let wrapper = mapped
+        .into_unsorted_iter()
+        .find(|ndt| ndt.name == "GenericOptionExternalPayloadWrapper")
+        .and_then(|ndt| ndt.ty.as_ref())
+        .expect("mapped generic option wrapper definition should exist");
+    assert!(
+        contains_named_field(wrapper, "Newtype", |ty| matches!(
+            ty,
+            DataType::Nullable(inner) if !matches!(inner.as_ref(), DataType::Nullable(_))
+        )),
+        "the contextual payload must remain `Option<T>`, not `Option<Option<T>>`: {wrapper:#?}"
+    );
 }
 
 #[test]

--- a/tests/tests/serde_internal_tag_payloads.rs
+++ b/tests/tests/serde_internal_tag_payloads.rs
@@ -46,6 +46,67 @@ impl From<ConvertedMapWire> for ConvertedScalar {
 
 #[derive(Type, Serialize, Deserialize)]
 #[specta(collect = false)]
+struct GenericConvertedWire<T> {
+    converted_value: T,
+}
+
+#[derive(Clone, Type, Serialize, Deserialize)]
+#[specta(bound = "T: Clone + Type", collect = false)]
+#[serde(
+    into = "GenericConvertedWire<T>",
+    from = "GenericConvertedWire<T>",
+    bound(
+        serialize = "T: Clone + Serialize",
+        deserialize = "T: Deserialize<'de>"
+    )
+)]
+struct GenericConverted<T>(T);
+
+impl<T> From<GenericConverted<T>> for GenericConvertedWire<T> {
+    fn from(value: GenericConverted<T>) -> Self {
+        Self {
+            converted_value: value.0,
+        }
+    }
+}
+
+impl<T> From<GenericConvertedWire<T>> for GenericConverted<T> {
+    fn from(value: GenericConvertedWire<T>) -> Self {
+        Self(value.converted_value)
+    }
+}
+
+#[derive(Clone, Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+struct ConvertedEmptyWire {}
+
+#[derive(Clone, Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(into = "ConvertedEmptyWire", from = "ConvertedEmptyWire")]
+struct ConvertedUnit;
+
+impl From<ConvertedUnit> for ConvertedEmptyWire {
+    fn from(_: ConvertedUnit) -> Self {
+        Self {}
+    }
+}
+
+impl From<ConvertedEmptyWire> for ConvertedUnit {
+    fn from(_: ConvertedEmptyWire) -> Self {
+        Self
+    }
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(untagged)]
+enum UntaggedConvertedEmpty {
+    Converted(ConvertedUnit),
+    Map { value: i32 },
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
 struct HiddenNewtype(#[specta(skip)] i32);
 
 #[derive(Type, Serialize, Deserialize)]
@@ -72,6 +133,13 @@ enum NewtypePayloads {
 #[serde(tag = "kind")]
 enum ConvertedPayloadWrapper {
     Value(ConvertedScalar),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum GenericConvertedPayloadWrapper {
+    Value(GenericConverted<i32>),
 }
 
 #[derive(Type, Serialize, Deserialize)]
@@ -593,6 +661,9 @@ fn format_accepts_newtype_unit_and_generic_payloads() {
         .map_types(&Types::default().register::<ConvertedPayloadWrapper>())
         .expect("map-shaped conversion wires are valid internally tagged payloads");
     specta_serde::Format
+        .map_types(&Types::default().register::<GenericPayload<UntaggedConvertedEmpty>>())
+        .expect("converted empty branches use their map-shaped wire encoding");
+    specta_serde::Format
         .map_types(&Types::default().register::<GenericPayload<Inner>>())
         .expect("generic payloads must be validated at their concrete use site");
     specta_serde::Format
@@ -671,6 +742,24 @@ fn format_accepts_newtype_unit_and_generic_payloads() {
     assert!(
         err.to_string().contains("context-sensitive enum encoding"),
         "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn generic_conversion_wire_substitutes_concrete_arguments() {
+    let mapped = specta_serde::Format
+        .map_types(&Types::default().register::<GenericConvertedPayloadWrapper>())
+        .expect("a concrete generic conversion wire is a valid map payload")
+        .into_owned();
+    let wrapper = mapped
+        .into_unsorted_iter()
+        .find(|ndt| ndt.name == "GenericConvertedPayloadWrapper")
+        .and_then(|ndt| ndt.ty.as_ref())
+        .expect("mapped wrapper definition should exist");
+
+    assert!(
+        !contains_generic(wrapper),
+        "conversion attributes must not retain the generic placeholder: {wrapper:#?}"
     );
 }
 
@@ -1275,6 +1364,58 @@ fn contains_named_field(
         DataType::Primitive(_)
         | DataType::Reference(specta::datatype::Reference::Opaque(_))
         | DataType::Generic(_) => false,
+    }
+}
+
+fn contains_generic(ty: &DataType) -> bool {
+    match ty {
+        DataType::Generic(_) => true,
+        DataType::Struct(strct) => match &strct.fields {
+            specta::datatype::Fields::Unit => false,
+            specta::datatype::Fields::Unnamed(fields) => fields
+                .fields
+                .iter()
+                .filter_map(|field| field.ty.as_ref())
+                .any(contains_generic),
+            specta::datatype::Fields::Named(fields) => fields
+                .fields
+                .iter()
+                .filter_map(|(_, field)| field.ty.as_ref())
+                .any(contains_generic),
+        },
+        DataType::Enum(enm) => enm.variants.iter().any(|(_, variant)| {
+            let fields = match &variant.fields {
+                specta::datatype::Fields::Unit => return false,
+                specta::datatype::Fields::Unnamed(fields) => fields
+                    .fields
+                    .iter()
+                    .filter_map(|field| field.ty.as_ref())
+                    .collect::<Vec<_>>(),
+                specta::datatype::Fields::Named(fields) => fields
+                    .fields
+                    .iter()
+                    .filter_map(|(_, field)| field.ty.as_ref())
+                    .collect::<Vec<_>>(),
+            };
+            fields.into_iter().any(contains_generic)
+        }),
+        DataType::Tuple(tuple) => tuple.elements.iter().any(contains_generic),
+        DataType::List(list) => contains_generic(&list.ty),
+        DataType::Map(map) => contains_generic(map.key_ty()) || contains_generic(map.value_ty()),
+        DataType::Intersection(parts) => parts.iter().any(contains_generic),
+        DataType::Nullable(inner) => contains_generic(inner),
+        DataType::Reference(specta::datatype::Reference::Named(reference)) => {
+            match &reference.inner {
+                specta::datatype::NamedReferenceType::Inline { dt, .. } => contains_generic(dt),
+                specta::datatype::NamedReferenceType::Reference { generics, .. } => generics
+                    .iter()
+                    .any(|(_, argument)| contains_generic(argument)),
+                specta::datatype::NamedReferenceType::Recursive(_) => false,
+            }
+        }
+        DataType::Primitive(_) | DataType::Reference(specta::datatype::Reference::Opaque(_)) => {
+            false
+        }
     }
 }
 

--- a/tests/tests/serde_internal_tag_payloads.rs
+++ b/tests/tests/serde_internal_tag_payloads.rs
@@ -343,6 +343,26 @@ enum UntaggedMapPayloadWithSkippedScalar {
 
 #[derive(Type, Serialize, Deserialize)]
 #[specta(collect = false)]
+struct AttributedMapInner {
+    extra: i32,
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(untagged)]
+enum UntaggedAttributedMapPayload {
+    Unit,
+    Live {
+        #[serde(rename = "wire_value", alias = "old_value")]
+        value: i32,
+        #[serde(flatten)]
+        #[specta(inline)]
+        inner: AttributedMapInner,
+    },
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
 #[serde(tag = "kind")]
 enum UntaggedExternalPayloadWrapper {
     Value(UntaggedExternalPayload),
@@ -360,6 +380,13 @@ enum UntaggedExternalPayloadWithSkippedScalarWrapper {
 #[serde(tag = "kind")]
 enum UntaggedMapPayloadWithSkippedScalarWrapper {
     Value(UntaggedMapPayloadWithSkippedScalar),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum UntaggedAttributedMapPayloadWrapper {
+    Value(UntaggedAttributedMapPayload),
 }
 
 #[derive(Type, Serialize, Deserialize)]
@@ -912,6 +939,49 @@ fn nested_untagged_enum_propagates_contextual_external_shape() {
         !contains_string_primitive(wrapper),
         "the skipped scalar branch must not leak into the replacement: {wrapper:#?}"
     );
+
+    assert_eq!(
+        serde_json::to_value(UntaggedAttributedMapPayloadWrapper::Value(
+            UntaggedAttributedMapPayload::Live {
+                value: 1,
+                inner: AttributedMapInner { extra: 2 },
+            }
+        ))
+        .unwrap(),
+        serde_json::json!({ "kind": "Value", "wire_value": 1, "extra": 2 })
+    );
+    let mapped = specta_serde::PhasesFormat
+        .map_types(&Types::default().register::<UntaggedAttributedMapPayloadWrapper>())
+        .expect("untagged contextual replacements must lower their surviving map fields")
+        .into_owned();
+    let mapped = mapped.into_unsorted_iter().collect::<Vec<_>>();
+    for (name, alias_expected) in [
+        ("UntaggedAttributedMapPayloadWrapper_Serialize", false),
+        ("UntaggedAttributedMapPayloadWrapper_Deserialize", true),
+    ] {
+        let wrapper = mapped
+            .iter()
+            .find(|ndt| ndt.name == name)
+            .and_then(|ndt| ndt.ty.as_ref())
+            .unwrap_or_else(|| panic!("mapped attributed wrapper `{name}` should exist"));
+        assert!(contains_named_field(wrapper, "wire_value", |ty| matches!(
+            ty,
+            DataType::Primitive(specta::datatype::Primitive::i32)
+        )));
+        assert_eq!(
+            contains_named_field(wrapper, "old_value", |ty| matches!(
+                ty,
+                DataType::Primitive(specta::datatype::Primitive::i32)
+            )),
+            alias_expected
+        );
+        assert!(contains_named_field(wrapper, "extra", |ty| matches!(
+            ty,
+            DataType::Primitive(specta::datatype::Primitive::i32)
+        )));
+        assert!(!contains_named_field(wrapper, "value", |_| true));
+        assert!(!contains_named_field(wrapper, "inner", |_| true));
+    }
 }
 
 #[test]
@@ -1023,7 +1093,18 @@ fn contains_named_field(
             contains_named_field(map.key_ty(), expected_name, expected_ty)
                 || contains_named_field(map.value_ty(), expected_name, expected_ty)
         }
-        DataType::Primitive(_) | DataType::Reference(_) | DataType::Generic(_) => false,
+        DataType::Reference(specta::datatype::Reference::Named(reference)) => {
+            match &reference.inner {
+                specta::datatype::NamedReferenceType::Inline { dt, .. } => {
+                    contains_named_field(dt, expected_name, expected_ty)
+                }
+                specta::datatype::NamedReferenceType::Reference { .. }
+                | specta::datatype::NamedReferenceType::Recursive(_) => false,
+            }
+        }
+        DataType::Primitive(_)
+        | DataType::Reference(specta::datatype::Reference::Opaque(_))
+        | DataType::Generic(_) => false,
     }
 }
 

--- a/tests/tests/serde_internal_tag_payloads.rs
+++ b/tests/tests/serde_internal_tag_payloads.rs
@@ -173,6 +173,62 @@ enum HiddenNamedPayload {
     Value(HiddenNamedNewtype),
 }
 
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+enum ExternalHiddenPayload {
+    Newtype(#[specta(skip)] i32),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum InlineExternalHiddenPayloadWrapper {
+    Value(#[specta(inline)] ExternalHiddenPayload),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+enum ExternalUntaggedHiddenPayload {
+    Live {
+        value: i32,
+    },
+    #[serde(untagged)]
+    Hidden(#[specta(skip)] i32),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum InlineExternalUntaggedHiddenPayloadWrapper {
+    Value(#[specta(inline)] ExternalUntaggedHiddenPayload),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+enum ExternalHiddenTuplePayload {
+    Tuple(#[specta(skip)] i32, #[specta(skip)] i32),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum ExternalHiddenTuplePayloadWrapper {
+    Value(ExternalHiddenTuplePayload),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+enum ExternalPartiallyHiddenTuplePayload {
+    Tuple(#[specta(skip)] i32, i32),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum ExternalPartiallyHiddenTuplePayloadWrapper {
+    Value(ExternalPartiallyHiddenTuplePayload),
+}
+
 #[derive(Debug, PartialEq, Type, Serialize, Deserialize)]
 #[specta(collect = false)]
 #[serde(tag = "kind")]
@@ -1061,6 +1117,10 @@ fn specta_hidden_newtype_payloads_are_rejected() {
         Types::default().register::<DirectHiddenNamedPayload>(),
         Types::default().register::<HiddenNamedPayload>(),
         Types::default().register::<ExternalWithHiddenPayloadWrapper>(),
+        Types::default().register::<InlineExternalHiddenPayloadWrapper>(),
+        Types::default().register::<InlineExternalUntaggedHiddenPayloadWrapper>(),
+        Types::default().register::<ExternalHiddenTuplePayloadWrapper>(),
+        Types::default().register::<ExternalPartiallyHiddenTuplePayloadWrapper>(),
         Types::default().register::<GenericPayload<HiddenNamed>>(),
     ] {
         assert!(

--- a/tests/tests/serde_internal_tag_payloads.rs
+++ b/tests/tests/serde_internal_tag_payloads.rs
@@ -287,6 +287,13 @@ enum ExternalWithInvalidUntagged {
 
 #[derive(Type, Serialize)]
 #[specta(collect = false)]
+enum ExternalWithInvalidUntaggedTuple {
+    #[serde(untagged)]
+    Tuple(i32, i32),
+}
+
+#[derive(Type, Serialize)]
+#[specta(collect = false)]
 enum ExternalWithUntaggedUnit {
     #[serde(untagged)]
     Unit,
@@ -341,6 +348,13 @@ enum InlineExternalWithOtherWrapper {
 #[serde(tag = "kind")]
 enum InvalidUntaggedExternalWrapper {
     Value(ExternalWithInvalidUntagged),
+}
+
+#[derive(Type, Serialize)]
+#[specta(collect = false)]
+#[serde(tag = "kind")]
+enum InlineInvalidUntaggedExternalWrapper {
+    Value(#[specta(inline)] ExternalWithInvalidUntaggedTuple),
 }
 
 #[derive(Type, Serialize)]
@@ -853,13 +867,25 @@ fn contextual_untagged_scalar_payload_is_rejected() {
         .is_err()
     );
 
-    let err = specta_serde::Format
-        .map_types(&Types::default().register::<InvalidUntaggedExternalWrapper>())
-        .expect_err("TaggedSerializer rejects scalar untagged payloads");
     assert!(
-        err.to_string().contains("cannot be merged"),
-        "unexpected error: {err}"
+        serde_json::to_value(InlineInvalidUntaggedExternalWrapper::Value(
+            ExternalWithInvalidUntaggedTuple::Tuple(1, 2)
+        ))
+        .is_err()
     );
+
+    for types in [
+        Types::default().register::<InvalidUntaggedExternalWrapper>(),
+        Types::default().register::<InlineInvalidUntaggedExternalWrapper>(),
+    ] {
+        let err = specta_serde::Format
+            .map_types(&types)
+            .expect_err("TaggedSerializer rejects scalar and tuple untagged payloads");
+        assert!(
+            err.to_string().contains("cannot be merged"),
+            "unexpected error: {err}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- accept valid internally tagged newtype, unit, transparent, and concrete generic payloads
- model serde `TaggedSerializer` contextual encoding for nested external and untagged enums
- reject payload shapes whose hidden, scalar, catch-all, or context-sensitive wire form cannot be represented safely
- add focused format-level and serde ground-truth regression coverage for G2–G4

## Root cause

The validation and compatibility walkers disagreed on which payloads serde can merge into an internal tag. They also reused standalone external-enum representations inside `TaggedSerializer`, where unit-like and nested enum payloads have different contextual map forms.

## Impact

Valid newtype/unit/generic payloads no longer fail spuriously, while contextual enum payloads now either lower to their actual serde wire shape or return an explicit error when that shape cannot be represented soundly.

## Validation

- `cargo test -p specta-tests --test test` (428 passed before rebasing; focused suite rerun after rebasing)
- `cargo test -p specta-tests --test test serde_internal_tag_payloads -- --nocapture` (16 passed after rebasing)
- `cargo clippy -p specta-serde --lib --no-deps -- -D warnings`
- `cargo clippy -p specta-tests --test test --no-deps -- -A clippy::derivable_impls -D warnings`
- `cargo fmt --all -- --check`
- independent subagent review and automated local review-fix loop: no actionable findings