### PR TITLE
Fix derive macro attribute handling and generic overrides

### DIFF
--- a/specta-macros/src/type/attr/container.rs
+++ b/specta-macros/src/type/attr/container.rs
@@ -25,7 +25,7 @@ pub struct ContainerAttr {
 }
 
 impl ContainerAttr {
-    pub fn from_attrs(attrs: &mut Vec<Attribute>) -> Result<Self> {
+    pub fn from_attrs(attrs: &mut Vec<Attribute>, is_struct: bool) -> Result<Self> {
         let mut result = Self {
             common: RustCAttr::from_attrs(attrs)?,
             ..Default::default()
@@ -63,7 +63,7 @@ impl ContainerAttr {
 
         if let Some(attr) = attrs.extract("specta", "transparent") {
             result.transparent = attr.parse_bool_or_true()?;
-        } else if let Some(attr) = attrs.extract("repr", "transparent") {
+        } else if is_struct && let Some(attr) = attrs.extract("repr", "transparent") {
             result.transparent = attr.parse_bool_or_true()?;
         } else if let Some(attr) = attrs.extract("serde", "transparent") {
             // We generally want `#[serde(...)]` attributes to only be handled by the runtime but,

--- a/specta-macros/src/type/attr/rustc.rs
+++ b/specta-macros/src/type/attr/rustc.rs
@@ -107,7 +107,9 @@ fn parse_deprecated_string_attr(
 }
 
 pub(crate) fn deprecated_as_tokens(Deprecated { note, since }: Deprecated) -> TokenStream {
-    let since = since.map(|v| quote!(#v.into())).unwrap_or(quote!(None));
+    let since = since
+        .map(|v| quote!(Some(#v.into())))
+        .unwrap_or(quote!(None));
 
     let note = match note {
         Some(note) => quote!(Some(#note.into())),

--- a/specta-macros/src/type/attr/rustc.rs
+++ b/specta-macros/src/type/attr/rustc.rs
@@ -43,17 +43,18 @@ pub struct RustCAttr {
 
 impl RustCAttr {
     pub fn from_attrs(attrs: &mut Vec<Attribute>) -> Result<Self> {
-        let doc = attrs.extract_if(.., |attr| attr.key == "doc").try_fold(
-            String::new(),
-            |mut s, doc| {
+        let doc = attrs
+            .extract_if(.., |attr| {
+                attr.key == "doc" && matches!(attr.value, Some(AttributeValue::Lit(Lit::Str(_))))
+            })
+            .try_fold(String::new(), |mut s, doc| {
                 let doc = doc.parse_string()?;
                 if !s.is_empty() {
                     s.push('\n');
                 }
                 s.push_str(&doc);
                 Ok(s) as syn::Result<_>
-            },
-        )?;
+            })?;
 
         let mut deprecated = None;
         if let Some(pos) = attrs.iter().position(|attr| attr.key == "deprecated") {

--- a/specta-macros/src/type/generics.rs
+++ b/specta-macros/src/type/generics.rs
@@ -145,12 +145,19 @@ pub fn used_type_params(
             }
             Data::Enum(data) => {
                 for variant in &data.variants {
-                    if variant_is_skipped(variant, skip_attrs)? {
+                    let mut attrs = parse_attrs_with_filter(&variant.attrs, skip_attrs)?;
+                    let attrs = VariantAttr::from_attrs(&mut attrs)?;
+
+                    if attrs.skip {
                         continue;
                     }
 
-                    for field in &variant.fields {
-                        visit_field_type(&mut visitor, field, skip_attrs)?;
+                    if let Some(ty) = &attrs.r#type {
+                        visitor.visit_type(ty);
+                    } else {
+                        for field in &variant.fields {
+                            visit_field_type(&mut visitor, field, skip_attrs)?;
+                        }
                     }
                 }
             }
@@ -186,11 +193,6 @@ fn visit_field_type(
     }
 
     Ok(())
-}
-
-fn variant_is_skipped(variant: &syn::Variant, skip_attrs: &[String]) -> syn::Result<bool> {
-    let mut attrs = parse_attrs_with_filter(&variant.attrs, skip_attrs)?;
-    Ok(VariantAttr::from_attrs(&mut attrs)?.skip)
 }
 
 pub fn add_type_to_where_clause(

--- a/specta-macros/src/type/mod.rs
+++ b/specta-macros/src/type/mod.rs
@@ -103,7 +103,7 @@ pub fn derive(input: proc_macro::TokenStream) -> syn::Result<proc_macro::TokenSt
     let raw_attrs = attrs; // Preserve raw attrs before parse_attrs shadows the variable
     let mut attrs = parse_attrs(attrs)?;
 
-    let container_attrs = ContainerAttr::from_attrs(&mut attrs)?;
+    let container_attrs = ContainerAttr::from_attrs(&mut attrs, matches!(data, Data::Struct(_)))?;
     let crate_ref = container_attrs.crate_name.clone().unwrap_or(quote!(specta));
 
     if container_attrs.r#type.is_some() && container_attrs.transparent {

--- a/tests/tests/macro_doc_attrs.rs
+++ b/tests/tests/macro_doc_attrs.rs
@@ -1,0 +1,39 @@
+use specta::Type;
+
+#[derive(Type)]
+#[specta(collect = false)]
+#[doc(hidden)]
+struct DocHiddenContainer {
+    #[doc(hidden)]
+    value: String,
+}
+
+#[derive(Type)]
+#[specta(collect = false)]
+#[doc = concat!("generated", " docs")]
+struct GeneratedDocsContainer {
+    value: String,
+}
+
+#[derive(Type)]
+#[specta(collect = false)]
+#[doc = include_str!("../../README.md")]
+struct IncludedDocsContainer {
+    value: String,
+}
+
+#[derive(Type)]
+#[specta(collect = false)]
+enum DocHiddenVariant {
+    #[doc(hidden)]
+    Value(#[doc = concat!("generated", " field docs")] String),
+}
+
+#[test]
+fn non_literal_doc_attributes_are_ignored() {
+    let mut types = specta::Types::default();
+    DocHiddenContainer::definition(&mut types);
+    GeneratedDocsContainer::definition(&mut types);
+    IncludedDocsContainer::definition(&mut types);
+    DocHiddenVariant::definition(&mut types);
+}

--- a/tests/tests/macro_generic_variant_override.rs
+++ b/tests/tests/macro_generic_variant_override.rs
@@ -1,0 +1,33 @@
+use specta::{
+    Type,
+    datatype::{DataType, Reference},
+};
+
+#[derive(Type)]
+#[specta(collect = false)]
+enum VariantTypeOverride<T> {
+    #[specta(type = Vec<T>)]
+    Value(u32),
+    #[specta(skip)]
+    Marker(std::marker::PhantomData<T>),
+}
+
+#[test]
+fn variant_type_override_registers_used_generic() {
+    let mut types = specta::Types::default();
+    let DataType::Reference(Reference::Named(reference)) =
+        VariantTypeOverride::<String>::definition(&mut types)
+    else {
+        panic!("derived named type should produce a reference");
+    };
+    assert_eq!(
+        types
+            .get(&reference)
+            .expect("type should be registered")
+            .generics
+            .iter()
+            .map(|generic| generic.name.as_ref())
+            .collect::<Vec<_>>(),
+        ["T"]
+    );
+}

--- a/tests/tests/macro_repr_transparent_enum.rs
+++ b/tests/tests/macro_repr_transparent_enum.rs
@@ -1,0 +1,13 @@
+use specta::Type;
+
+#[derive(Type)]
+#[specta(collect = false)]
+#[repr(transparent)]
+enum ReprTransparentEnum {
+    Value(String),
+}
+
+#[test]
+fn repr_transparent_enum_derives_type() {
+    ReprTransparentEnum::definition(&mut specta::Types::default());
+}

--- a/tests/tests/macro_structured_deprecated.rs
+++ b/tests/tests/macro_structured_deprecated.rs
@@ -1,0 +1,28 @@
+#![allow(deprecated)]
+
+use specta::{
+    Type,
+    datatype::{DataType, Reference},
+};
+
+#[derive(Type)]
+#[specta(collect = false)]
+#[deprecated(since = "1.0.0", note = "use NewType")]
+struct DeprecatedSince {
+    value: String,
+}
+
+#[test]
+fn structured_deprecated_since_is_recorded() {
+    let mut types = specta::Types::default();
+    let DataType::Reference(Reference::Named(reference)) = DeprecatedSince::definition(&mut types)
+    else {
+        panic!("derived named type should produce a reference");
+    };
+    let deprecated = types
+        .get(&reference)
+        .and_then(|ndt| ndt.deprecated.as_ref())
+        .expect("deprecated metadata should be recorded");
+    assert_eq!(deprecated.since.as_deref(), Some("1.0.0"));
+    assert_eq!(deprecated.note.as_deref(), Some("use NewType"));
+}

--- a/tests/tests/mod.rs
+++ b/tests/tests/mod.rs
@@ -23,6 +23,7 @@ mod jsonschema;
 mod kotlin;
 mod layouts;
 mod legacy_impls;
+mod macro_doc_attrs;
 mod maybe_undefined;
 mod openapi;
 mod python;

--- a/tests/tests/mod.rs
+++ b/tests/tests/mod.rs
@@ -24,6 +24,7 @@ mod kotlin;
 mod layouts;
 mod legacy_impls;
 mod macro_doc_attrs;
+mod macro_structured_deprecated;
 mod maybe_undefined;
 mod openapi;
 mod python;

--- a/tests/tests/mod.rs
+++ b/tests/tests/mod.rs
@@ -24,6 +24,7 @@ mod kotlin;
 mod layouts;
 mod legacy_impls;
 mod macro_doc_attrs;
+mod macro_repr_transparent_enum;
 mod macro_structured_deprecated;
 mod maybe_undefined;
 mod openapi;

--- a/tests/tests/mod.rs
+++ b/tests/tests/mod.rs
@@ -24,6 +24,7 @@ mod kotlin;
 mod layouts;
 mod legacy_impls;
 mod macro_doc_attrs;
+mod macro_generic_variant_override;
 mod macro_repr_transparent_enum;
 mod macro_structured_deprecated;
 mod maybe_undefined;


### PR DESCRIPTION
## Summary

Fix four independently confirmed derive-macro issues, with one focused commit and regression test per issue:

- **A2 — non-literal Rust doc attributes:** ignore valid `#[doc(hidden)]`, `concat!(...)`, and `include_str!(...)` forms while continuing to collect literal documentation.
- **A3 — structured deprecation metadata:** emit `since` as `Some(Cow)` so `#[deprecated(since = "...", note = "...")]` compiles and retains both values.
- **A4 — `repr(transparent)` enums:** only treat `repr(transparent)` as Specta transparency for structs; valid single-variant enums remain enums.
- **B2 — variant type override generics:** include generics referenced only by variant-level `#[specta(type = ...)]` overrides in generated bounds and named datatype metadata.

No exporter implementation or exporter-specific snapshot is changed.

## Commit structure

1. `Accept non-literal doc attributes` (A2)
2. `Fix structured deprecation metadata` (A3)
3. `Allow repr transparent enums` (A4)
4. `Track generics in variant type overrides` (B2)

## Validation

- `cargo fmt --all -- --check`
- focused macro regressions: 4 passed
- `cargo clippy -p specta-macros --all-targets --all-features -- -D warnings`

## Explicitly unresolved

**B1 (declared trait bounds dropped from generated `build`) is not included.** Copying bounds is unsound because canonical named-type construction instantiates `build::<PLACEHOLDER_T>()`, and placeholders cannot implement arbitrary user traits. A safe functional fix needs a broader core `Type`/generic-constructor metadata redesign.
