### PR TITLE
fix(openapi): point strict-mode errors at SchemaMode::Compatible

### DIFF
--- a/specta-openapi/src/error.rs
+++ b/specta-openapi/src/error.rs
@@ -18,7 +18,11 @@ pub enum Error {
     },
 
     /// A Specta shape cannot be represented exactly by OpenAPI 3.0.
-    #[error("OpenAPI 3.0 cannot represent {feature} exactly in component {component:?}")]
+    #[error(
+        "OpenAPI 3.0 cannot represent {feature} exactly in component {component:?}. \
+         Export with SchemaMode::Compatible to emit the closest schema and keep the exact \
+         constraints in x-specta-* extensions."
+    )]
     UnsupportedSchemaFeature {
         /// Component containing the unsupported shape.
         component: String,

--- a/specta-openapi/src/lib.rs
+++ b/specta-openapi/src/lib.rs
@@ -39,8 +39,10 @@
 //! [`SchemaMode::Strict`] returns an error for structural schema features which
 //! the specification cannot express. Opt into [`SchemaMode::Compatible`] to emit a useful
 //! approximation and retain the original constraints in `x-specta-*`
-//! extensions. This affects null-only types, heterogeneous tuples, constrained
-//! map keys, and closed flattened intersections.
+//! extensions. This affects nullable references — an `Option<T>` over a named
+//! type, which OpenAPI 3.0 cannot mark `nullable` beside a `$ref` — along with
+//! exact 64-bit integer bounds, null-only types, heterogeneous tuples,
+//! constrained map keys, and closed flattened intersections.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(

--- a/tests/tests/openapi.rs
+++ b/tests/tests/openapi.rs
@@ -108,6 +108,12 @@ struct WideIntegers {
     unsigned: u64,
 }
 
+#[derive(Type)]
+#[specta(collect = false)]
+struct StrictOptionalReference {
+    value: Option<StrictUnit>,
+}
+
 #[derive(Type, Serialize, Deserialize)]
 #[specta(collect = false)]
 struct FlattenA {
@@ -399,6 +405,42 @@ fn openapi_strict_mode_rejects_lossy_openapi_3_shapes() {
     assert_eq!(flattened["additionalProperties"], false);
     assert!(flattened["properties"].get("a").is_some());
     assert!(flattened["properties"].get("b").is_some());
+
+    // `Option<T>` over a named type is the most common shape strict mode rejects: OpenAPI 3.0
+    // cannot mark a `$ref` nullable.
+    let reference_error = OpenApi::default()
+        .export_document(
+            &Types::default().register::<StrictOptionalReference>(),
+            specta_serde::Format,
+        )
+        .expect_err("OpenAPI 3.0 cannot represent a nullable reference exactly");
+    assert!(
+        reference_error
+            .to_string()
+            .contains("nullable references or composed schemas")
+    );
+    let compatible_reference = OpenApi::default()
+        .schema_mode(SchemaMode::Compatible)
+        .export_document(
+            &Types::default().register::<StrictOptionalReference>(),
+            specta_serde::Format,
+        )
+        .expect("compatible mode should approximate a nullable reference");
+    let compatible_reference = serde_json::to_value(compatible_reference).unwrap();
+    assert!(
+        compatible_reference["components"]["schemas"]["StrictOptionalReference"]["properties"]
+            ["value"]
+            .get("x-specta-nullable")
+            .is_some()
+    );
+
+    // Strict is the default, so every rejection names the way out.
+    for error in [&error, &map_error, &null_error, &reference_error] {
+        assert!(
+            error.to_string().contains("SchemaMode::Compatible"),
+            "strict-mode error should point at the escape hatch: {error}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Strict mode rejects `Option<T>` over a named type, which is about the most common shape in a Rust API. That's correct — OpenAPI 3.0 can't mark a `$ref` nullable — and since strict is the default, it's the first thing a lot of exports will hit.

The error named the problem but not the way out, so this appends the escape hatch to it:

```
OpenAPI 3.0 cannot represent nullable references or composed schemas exactly in component "Foo".
Export with SchemaMode::Compatible to emit the closest schema and keep the exact constraints in
x-specta-* extensions.
```

The module docs also list four of the six shapes this affects — nullable references and (since #529) exact 64-bit integer bounds weren't in the list, and nullable references is the most likely trigger of the six. Added both.

Also covers the nullable reference case, which had no test, and asserts every strict-mode rejection names the escape hatch.

Checks: `fmt`, `clippy --all-features`, `test --all-features`, `build --all --no-default-features` all pass. Existing tests assert on the feature substrings, so appending to the message leaves them alone.