### PR TITLE
feat(openapi): describe endpoints in the paths object

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2155,6 +2155,7 @@ dependencies = [
 name = "specta-openapi"
 version = "0.0.4"
 dependencies = [
+ "indexmap 2.14.0",
  "openapiv3",
  "serde_json",
  "serde_yaml",

--- a/specta-openapi/Cargo.toml
+++ b/specta-openapi/Cargo.toml
@@ -23,6 +23,7 @@ workspace = true
 specta = { version = "=2.0.0-rc.26", path = "../specta" }
 specta-jsonschema = { version = "=0.0.4", path = "../specta-jsonschema" }
 openapiv3 = { version = "2", default-features = false, features = [] }
+indexmap = "2"
 serde_json = "1"
 serde_yaml = "0.9"
 thiserror = "2"

--- a/specta-openapi/src/error.rs
+++ b/specta-openapi/src/error.rs
@@ -37,6 +37,39 @@ pub enum Error {
         second: String,
     },
 
+    /// An operation references a type that is not in the exported collection.
+    #[error(
+        "operation references type {type_name:?}, which is not registered in the exported collection"
+    )]
+    UnregisteredOperationType {
+        /// Name of the unregistered type.
+        type_name: String,
+    },
+
+    /// Two operations describe the same method and path.
+    #[error("duplicate operation {method} {path:?}")]
+    DuplicateOperation {
+        /// HTTP method.
+        method: String,
+        /// Templated path.
+        path: String,
+    },
+
+    /// An operation declares no responses.
+    #[error("operation {path:?} declares no responses")]
+    OperationWithoutResponses {
+        /// Templated path.
+        path: String,
+    },
+
+    /// An operation's types could not be resolved to components.
+    ///
+    /// Component names are obtained by asking the exporter what it names each referenced type. This
+    /// means it did not answer, and is raised rather than emitting a `$ref` that resolves to
+    /// nothing.
+    #[error("could not resolve operation types to exported components")]
+    UnresolvedOperationTypes,
+
     /// JSON output serialization failed.
     #[error("failed to serialize OpenAPI JSON: {0}")]
     Json(#[from] serde_json::Error),

--- a/specta-openapi/src/lib.rs
+++ b/specta-openapi/src/lib.rs
@@ -50,8 +50,12 @@
 
 mod error;
 mod openapi;
+mod operation;
+mod paths;
+mod resolve;
 mod transform;
 
 pub use error::Error;
 pub use openapi::{OpenApi, OutputFormat, SchemaMode};
 pub use openapiv3::{Components, OpenAPI, ReferenceOr, Schema};
+pub use operation::{Method, Operation};

--- a/specta-openapi/src/openapi.rs
+++ b/specta-openapi/src/openapi.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, path::Path};
 use openapiv3::{Components, Info, OpenAPI, Paths};
 use specta::{Format, Types};
 
-use crate::{Error, transform::components};
+use crate::{Error, operation::Operation, resolve::resolve, transform::components};
 
 /// How shapes unsupported by OpenAPI 3.0's schema dialect are handled.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -35,6 +35,7 @@ pub struct OpenApi {
     description: Option<Cow<'static, str>>,
     output_format: OutputFormat,
     schema_mode: SchemaMode,
+    operations: Vec<Operation>,
 }
 
 impl Default for OpenApi {
@@ -45,6 +46,7 @@ impl Default for OpenApi {
             description: None,
             output_format: OutputFormat::Json,
             schema_mode: SchemaMode::Strict,
+            operations: Vec::new(),
         }
     }
 }
@@ -86,8 +88,51 @@ impl OpenApi {
         self
     }
 
+    /// Describe an endpoint, which is exported into the document's `paths` object.
+    ///
+    /// Bodies are declared as types and resolved to their exported components, so the document and
+    /// the schemas cannot disagree. A handler that returns more than one status has no single Rust
+    /// return type to infer from, so each response is stated:
+    ///
+    /// ```rust
+    /// # use specta::{Type, Types};
+    /// # use specta_openapi::{OpenApi, Operation};
+    /// # #[derive(Type)]
+    /// # struct Recipe { name: String }
+    /// # #[derive(Type)]
+    /// # struct ApiError { message: String }
+    /// let types = Types::default().register::<Recipe>().register::<ApiError>();
+    /// let document = OpenApi::default()
+    ///     .operation(
+    ///         Operation::get("/recipes/{slug}")
+    ///             .path_param("slug")
+    ///             .response::<Recipe>(200, "The recipe")
+    ///             .response::<ApiError>(404, "No such recipe"),
+    ///     )
+    ///     .export(&types, specta_serde::Format)
+    ///     .unwrap();
+    /// assert!(document.contains("/recipes/{slug}"));
+    /// ```
+    pub fn operation(mut self, operation: Operation) -> Self {
+        self.operations.push(operation);
+        self
+    }
+
+    /// Describe several endpoints at once.
+    pub fn operations(mut self, operations: impl IntoIterator<Item = Operation>) -> Self {
+        self.operations.extend(operations);
+        self
+    }
+
     /// Export the supplied types as a complete OpenAPI 3.0 document.
     pub fn export_document(&self, types: &Types, format: impl Format) -> Result<OpenAPI, Error> {
+        let (components, resolved) = resolve(types, &self.operations, format, self.schema_mode)?;
+        let paths = if self.operations.is_empty() {
+            Paths::default()
+        } else {
+            crate::paths::paths(&self.operations, &resolved)?
+        };
+
         Ok(OpenAPI {
             openapi: "3.0.3".to_string(),
             info: Info {
@@ -96,8 +141,8 @@ impl OpenApi {
                 version: self.version.to_string(),
                 ..Default::default()
             },
-            paths: Paths::default(),
-            components: Some(self.export_components(types, format)?),
+            paths,
+            components: Some(components),
             ..Default::default()
         })
     }

--- a/specta-openapi/src/operation.rs
+++ b/specta-openapi/src/operation.rs
@@ -1,0 +1,253 @@
+//! Description of a single endpoint, for the `paths` object.
+
+use std::borrow::Cow;
+
+use specta::{
+    Type, Types,
+    datatype::{DataType, NamedReference, Reference},
+};
+
+/// HTTP method an [`Operation`] is served on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Method {
+    /// `GET`
+    Get,
+    /// `POST`
+    Post,
+    /// `PUT`
+    Put,
+    /// `PATCH`
+    Patch,
+    /// `DELETE`
+    Delete,
+    /// `HEAD`
+    Head,
+    /// `OPTIONS`
+    Options,
+    /// `TRACE`
+    Trace,
+}
+
+/// Where a parameter is read from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ParameterLocation {
+    Path,
+    Query,
+    Header,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Parameter {
+    pub(crate) name: Cow<'static, str>,
+    pub(crate) location: ParameterLocation,
+    pub(crate) required: bool,
+    pub(crate) description: Option<Cow<'static, str>>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Body {
+    pub(crate) reference: NamedReference,
+    /// Rust's name for the type, which stays available even when the reference cannot be resolved
+    /// and is the only useful thing to say in that error.
+    pub(crate) type_name: &'static str,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Response {
+    pub(crate) status: u16,
+    pub(crate) description: Cow<'static, str>,
+    pub(crate) body: Option<Body>,
+}
+
+/// A single endpoint: one method on one path.
+///
+/// Bodies are given as types rather than names, and are resolved to their exported component when
+/// the document is built. The type must be registered in the [`Types`] passed to the exporter.
+///
+/// ```rust
+/// use specta::Type;
+/// use specta_openapi::Operation;
+///
+/// #[derive(Type)]
+/// struct Recipe { name: String }
+///
+/// let operation = Operation::get("/recipes/{slug}")
+///     .summary("Fetch one recipe")
+///     .path_param("slug")
+///     .response::<Recipe>(200, "The recipe");
+/// ```
+#[derive(Debug, Clone)]
+pub struct Operation {
+    pub(crate) method: Method,
+    pub(crate) path: Cow<'static, str>,
+    pub(crate) summary: Option<Cow<'static, str>>,
+    pub(crate) description: Option<Cow<'static, str>>,
+    pub(crate) operation_id: Option<Cow<'static, str>>,
+    pub(crate) tags: Vec<Cow<'static, str>>,
+    pub(crate) parameters: Vec<Parameter>,
+    pub(crate) request_body: Option<Body>,
+    pub(crate) responses: Vec<Response>,
+}
+
+impl Operation {
+    /// Describes an operation on `method` and `path`.
+    ///
+    /// Path templating follows OpenAPI: `/recipes/{slug}` expects a matching
+    /// [`path_param`](Self::path_param).
+    pub fn new(method: Method, path: impl Into<Cow<'static, str>>) -> Self {
+        Self {
+            method,
+            path: path.into(),
+            summary: None,
+            description: None,
+            operation_id: None,
+            tags: Vec::new(),
+            parameters: Vec::new(),
+            request_body: None,
+            responses: Vec::new(),
+        }
+    }
+
+    /// Describes a `GET` operation.
+    pub fn get(path: impl Into<Cow<'static, str>>) -> Self {
+        Self::new(Method::Get, path)
+    }
+
+    /// Describes a `POST` operation.
+    pub fn post(path: impl Into<Cow<'static, str>>) -> Self {
+        Self::new(Method::Post, path)
+    }
+
+    /// Describes a `PUT` operation.
+    pub fn put(path: impl Into<Cow<'static, str>>) -> Self {
+        Self::new(Method::Put, path)
+    }
+
+    /// Describes a `PATCH` operation.
+    pub fn patch(path: impl Into<Cow<'static, str>>) -> Self {
+        Self::new(Method::Patch, path)
+    }
+
+    /// Describes a `DELETE` operation.
+    pub fn delete(path: impl Into<Cow<'static, str>>) -> Self {
+        Self::new(Method::Delete, path)
+    }
+
+    /// Sets the operation's short summary.
+    pub fn summary(mut self, summary: impl Into<Cow<'static, str>>) -> Self {
+        self.summary = Some(summary.into());
+        self
+    }
+
+    /// Sets the operation's long description.
+    pub fn description(mut self, description: impl Into<Cow<'static, str>>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Sets the operation's `operationId`, which generators use to name the produced client method.
+    pub fn operation_id(mut self, operation_id: impl Into<Cow<'static, str>>) -> Self {
+        self.operation_id = Some(operation_id.into());
+        self
+    }
+
+    /// Adds a tag, which generators use to group operations.
+    pub fn tag(mut self, tag: impl Into<Cow<'static, str>>) -> Self {
+        self.tags.push(tag.into());
+        self
+    }
+
+    /// Declares a templated path parameter. Path parameters are always required.
+    pub fn path_param(mut self, name: impl Into<Cow<'static, str>>) -> Self {
+        self.parameters.push(Parameter {
+            name: name.into(),
+            location: ParameterLocation::Path,
+            required: true,
+            description: None,
+        });
+        self
+    }
+
+    /// Declares an optional query parameter.
+    pub fn query_param(mut self, name: impl Into<Cow<'static, str>>) -> Self {
+        self.parameters.push(Parameter {
+            name: name.into(),
+            location: ParameterLocation::Query,
+            required: false,
+            description: None,
+        });
+        self
+    }
+
+    /// Declares an optional header parameter.
+    pub fn header_param(mut self, name: impl Into<Cow<'static, str>>) -> Self {
+        self.parameters.push(Parameter {
+            name: name.into(),
+            location: ParameterLocation::Header,
+            required: false,
+            description: None,
+        });
+        self
+    }
+
+    /// Declares the JSON request body as `T`.
+    pub fn request_body<T: Type>(mut self) -> Self {
+        self.request_body = capture::<T>();
+        self
+    }
+
+    /// Declares a JSON response body of `T` for `status`.
+    ///
+    /// Call once per status an endpoint can return; the multi-status case has no single Rust return
+    /// type to infer from, so it is stated rather than derived.
+    pub fn response<T: Type>(
+        mut self,
+        status: u16,
+        description: impl Into<Cow<'static, str>>,
+    ) -> Self {
+        self.responses.push(Response {
+            status,
+            description: description.into(),
+            body: capture::<T>(),
+        });
+        self
+    }
+
+    /// Every type this operation references.
+    pub(crate) fn bodies(&self) -> impl Iterator<Item = &Body> {
+        self.request_body.iter().chain(
+            self.responses
+                .iter()
+                .filter_map(|response| response.body.as_ref()),
+        )
+    }
+
+    /// Declares a response with no body, such as a `204`.
+    pub fn empty_response(
+        mut self,
+        status: u16,
+        description: impl Into<Cow<'static, str>>,
+    ) -> Self {
+        self.responses.push(Response {
+            status,
+            description: description.into(),
+            body: None,
+        });
+        self
+    }
+}
+
+/// Captures `T`'s reference so it can be resolved against the exporter's collection later.
+///
+/// The reference is taken from a scratch collection: a derived type's identity is its module path
+/// and name, so the reference stays resolvable against whichever collection is exported.
+fn capture<T: Type>() -> Option<Body> {
+    let mut scratch = Types::default();
+    match T::definition(&mut scratch) {
+        DataType::Reference(Reference::Named(reference)) => Some(Body {
+            reference,
+            type_name: std::any::type_name::<T>(),
+        }),
+        _ => None,
+    }
+}

--- a/specta-openapi/src/paths.rs
+++ b/specta-openapi/src/paths.rs
@@ -1,0 +1,161 @@
+//! Lowering of [`Operation`]s into the document's `paths` object.
+
+use std::collections::HashMap;
+
+use indexmap::IndexMap;
+use openapiv3::{
+    MediaType, Operation as OpenApiOperation, Parameter as OpenApiParameter, ParameterData,
+    ParameterSchemaOrContent, PathItem, Paths, ReferenceOr, RequestBody, Response, Responses,
+    Schema, SchemaData, SchemaKind, StatusCode, StringType, Type as SchemaType,
+};
+use specta::datatype::NamedReference;
+
+use crate::{
+    Error,
+    operation::{Body, Method, Operation, ParameterLocation},
+};
+
+const JSON: &str = "application/json";
+
+pub(crate) fn paths(
+    operations: &[Operation],
+    resolved: &HashMap<NamedReference, String>,
+) -> Result<Paths, Error> {
+    let mut paths: IndexMap<String, ReferenceOr<PathItem>> = IndexMap::new();
+
+    for operation in operations {
+        let lowered = lower(operation, resolved)?;
+        let entry = paths
+            .entry(operation.path.to_string())
+            .or_insert_with(|| ReferenceOr::Item(PathItem::default()));
+        let ReferenceOr::Item(item) = entry else {
+            continue;
+        };
+
+        let slot = match operation.method {
+            Method::Get => &mut item.get,
+            Method::Post => &mut item.post,
+            Method::Put => &mut item.put,
+            Method::Patch => &mut item.patch,
+            Method::Delete => &mut item.delete,
+            Method::Head => &mut item.head,
+            Method::Options => &mut item.options,
+            Method::Trace => &mut item.trace,
+        };
+        if slot.is_some() {
+            return Err(Error::DuplicateOperation {
+                method: format!("{:?}", operation.method).to_uppercase(),
+                path: operation.path.to_string(),
+            });
+        }
+        *slot = Some(lowered);
+    }
+
+    Ok(Paths {
+        paths,
+        ..Default::default()
+    })
+}
+
+fn lower(
+    operation: &Operation,
+    resolved: &HashMap<NamedReference, String>,
+) -> Result<OpenApiOperation, Error> {
+    if operation.responses.is_empty() {
+        return Err(Error::OperationWithoutResponses {
+            path: operation.path.to_string(),
+        });
+    }
+
+    let mut responses = Responses::default();
+    for response in &operation.responses {
+        responses.responses.insert(
+            StatusCode::Code(response.status),
+            ReferenceOr::Item(Response {
+                description: response.description.to_string(),
+                content: content_of(response.body.as_ref(), resolved)?,
+                ..Default::default()
+            }),
+        );
+    }
+
+    let request_body = match &operation.request_body {
+        Some(body) => Some(ReferenceOr::Item(RequestBody {
+            content: content_of(Some(body), resolved)?,
+            required: true,
+            ..Default::default()
+        })),
+        None => None,
+    };
+
+    Ok(OpenApiOperation {
+        tags: operation.tags.iter().map(ToString::to_string).collect(),
+        summary: operation.summary.as_ref().map(ToString::to_string),
+        description: operation.description.as_ref().map(ToString::to_string),
+        operation_id: operation.operation_id.as_ref().map(ToString::to_string),
+        parameters: operation.parameters.iter().map(parameter).collect(),
+        request_body,
+        responses,
+        ..Default::default()
+    })
+}
+
+fn content_of(
+    body: Option<&Body>,
+    resolved: &HashMap<NamedReference, String>,
+) -> Result<IndexMap<String, MediaType>, Error> {
+    let Some(body) = body else {
+        return Ok(IndexMap::new());
+    };
+    let reference = resolved
+        .get(&body.reference)
+        .ok_or(Error::UnresolvedOperationTypes)?;
+    Ok(IndexMap::from_iter([(
+        JSON.to_string(),
+        MediaType {
+            schema: Some(ReferenceOr::Reference {
+                reference: reference.clone(),
+            }),
+            ..Default::default()
+        },
+    )]))
+}
+
+/// Parameters are declared by name and typed as strings.
+///
+/// A path or query parameter arrives as text and is parsed by the extractor, so `string` is what
+/// the wire actually carries. Richer parameter schemas are a separate question from the bodies this
+/// is here to type.
+fn parameter(parameter: &crate::operation::Parameter) -> ReferenceOr<OpenApiParameter> {
+    let data = ParameterData {
+        name: parameter.name.to_string(),
+        description: parameter.description.as_ref().map(ToString::to_string),
+        required: parameter.required,
+        deprecated: None,
+        format: ParameterSchemaOrContent::Schema(ReferenceOr::Item(Schema {
+            schema_data: SchemaData::default(),
+            schema_kind: SchemaKind::Type(SchemaType::String(StringType::default())),
+        })),
+        example: None,
+        examples: IndexMap::new(),
+        explode: None,
+        extensions: IndexMap::new(),
+    };
+
+    ReferenceOr::Item(match parameter.location {
+        ParameterLocation::Path => OpenApiParameter::Path {
+            parameter_data: data,
+            style: Default::default(),
+        },
+        ParameterLocation::Query => OpenApiParameter::Query {
+            parameter_data: data,
+            allow_reserved: false,
+            style: Default::default(),
+            allow_empty_value: None,
+        },
+        ParameterLocation::Header => OpenApiParameter::Header {
+            parameter_data: data,
+            style: Default::default(),
+        },
+    })
+}

--- a/specta-openapi/src/resolve.rs
+++ b/specta-openapi/src/resolve.rs
@@ -1,0 +1,90 @@
+//! Resolution of an operation's types to the components they are exported under.
+//!
+//! An operation names its bodies by type, but the component a type lands in is a property of the
+//! whole collection rather than of the type: definitions are disambiguated by module path when two
+//! share a name, generic instantiations fold their arguments into the name, and the result is then
+//! sanitised into a legal component name.
+//!
+//! Rather than reproduce those rules — which would be a copy of the JSON Schema exporter's
+//! internals, free to drift from them — this asks the exporter directly. A probe type holding one
+//! field per referenced type is exported alongside the real ones, and the `$ref` the exporter emits
+//! for each field is the answer. The probe is dropped from the components afterwards.
+
+use std::collections::HashMap;
+
+use openapiv3::{Components, ReferenceOr};
+use specta::{
+    Format, Types,
+    datatype::{DataType, Field, NamedDataType, NamedReference, Reference, Struct},
+};
+
+use crate::{Error, SchemaMode, operation::Operation, transform::components};
+
+/// Name of the probe definition. Carries a prefix no derived type will produce, so it cannot
+/// collide with a real definition and change how the real ones are named.
+const PROBE: &str = "__specta_openapi_probe";
+
+/// Exports `types`, and resolves every type referenced by `operations` to its component.
+///
+/// Returns the components with the probe removed, so the caller exports exactly what it would have
+/// without one.
+pub(crate) fn resolve(
+    types: &Types,
+    operations: &[Operation],
+    format: impl Format,
+    mode: SchemaMode,
+) -> Result<(Components, HashMap<NamedReference, String>), Error> {
+    let mut referenced: Vec<NamedReference> = Vec::new();
+    for operation in operations {
+        for body in operation.bodies() {
+            if !types.get(&body.reference).is_some() {
+                return Err(Error::UnregisteredOperationType {
+                    type_name: body.type_name.to_string(),
+                });
+            }
+            if !referenced.contains(&body.reference) {
+                referenced.push(body.reference.clone());
+            }
+        }
+    }
+
+    if referenced.is_empty() {
+        return Ok((components(types, format, mode)?, HashMap::new()));
+    }
+
+    let mut probe_types = types.clone();
+    let mut probe = Struct::named();
+    for (index, reference) in referenced.iter().enumerate() {
+        probe = probe.field(
+            field_name(index),
+            Field::new(DataType::Reference(Reference::Named(reference.clone()))),
+        );
+    }
+    let body = probe.build();
+    NamedDataType::new(PROBE, &mut probe_types, |_, ndt| {
+        ndt.ty = Some(body.clone());
+    });
+
+    let mut components = components(&probe_types, format, mode)?;
+    let Some(ReferenceOr::Item(schema)) = components.schemas.shift_remove(PROBE) else {
+        return Err(Error::UnresolvedOperationTypes);
+    };
+
+    let probe = serde_json::to_value(&schema)?;
+    let mut resolved = HashMap::new();
+    for (index, reference) in referenced.into_iter().enumerate() {
+        let component = probe
+            .get("properties")
+            .and_then(|properties| properties.get(field_name(index)))
+            .and_then(|property| property.get("$ref"))
+            .and_then(|reference| reference.as_str())
+            .ok_or(Error::UnresolvedOperationTypes)?;
+        resolved.insert(reference, component.to_string());
+    }
+
+    Ok((components, resolved))
+}
+
+fn field_name(index: usize) -> String {
+    format!("op_{index}")
+}

--- a/specta-openapi/src/transform.rs
+++ b/specta-openapi/src/transform.rs
@@ -52,7 +52,7 @@ pub(crate) fn components(
     Ok(components)
 }
 
-fn component_name(name: &str) -> String {
+pub(crate) fn component_name(name: &str) -> String {
     let mut output = String::with_capacity(name.len());
     let mut separator = false;
     for character in name.chars() {

--- a/tests/tests/openapi.rs
+++ b/tests/tests/openapi.rs
@@ -5,7 +5,7 @@ use specta::{
     Type, Types,
     datatype::{DataType, Field, NamedDataType, Primitive, Struct},
 };
-use specta_openapi::{OpenApi, OutputFormat, SchemaMode};
+use specta_openapi::{OpenApi, Operation, OutputFormat, SchemaMode};
 
 #[derive(Type, Serialize, Deserialize)]
 #[specta(collect = false)]
@@ -499,5 +499,255 @@ fn openapi_supports_yaml_export_to_and_document_merging() {
             .add_to_document(&mut document, &types, specta_serde::Format)
             .is_err(),
         "duplicate component names should never be overwritten"
+    );
+}
+
+#[derive(Type)]
+#[specta(collect = false)]
+struct Recipe {
+    slug: String,
+}
+
+#[derive(Type)]
+#[specta(collect = false)]
+struct NewRecipe {
+    slug: String,
+}
+
+#[derive(Type)]
+#[specta(collect = false)]
+struct ApiError {
+    message: String,
+}
+
+#[derive(Type)]
+#[specta(collect = false)]
+struct Wrapper<T> {
+    value: T,
+}
+
+mod other {
+    use specta::Type;
+
+    // Same name as the outer `Recipe`, which is what makes the exporter disambiguate both by
+    // module path.
+    #[derive(Type)]
+    #[specta(collect = false)]
+    pub struct Recipe {
+        pub id: u32,
+    }
+}
+
+fn recipe_types() -> Types {
+    Types::default()
+        .register::<Recipe>()
+        .register::<NewRecipe>()
+        .register::<ApiError>()
+}
+
+#[test]
+fn openapi_exports_operations_into_paths() {
+    let document = OpenApi::default()
+        .operation(
+            Operation::get("/recipes/{slug}")
+                .summary("Fetch one recipe")
+                .operation_id("getRecipe")
+                .tag("recipes")
+                .path_param("slug")
+                .response::<Recipe>(200, "The recipe")
+                .response::<ApiError>(404, "No such recipe"),
+        )
+        .operation(
+            Operation::post("/recipes")
+                .request_body::<NewRecipe>()
+                .response::<Recipe>(201, "The created recipe")
+                .empty_response(204, "Nothing to do"),
+        )
+        .export_document(&recipe_types(), specta_serde::Format)
+        .expect("operations should export");
+    let value = serde_json::to_value(&document).unwrap();
+
+    let get = &value["paths"]["/recipes/{slug}"]["get"];
+    assert_eq!(get["summary"], "Fetch one recipe");
+    assert_eq!(get["operationId"], "getRecipe");
+    assert_eq!(get["tags"][0], "recipes");
+    assert_eq!(get["parameters"][0]["name"], "slug");
+    assert_eq!(get["parameters"][0]["in"], "path");
+    assert_eq!(get["parameters"][0]["required"], true);
+    assert_eq!(
+        get["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+        "#/components/schemas/Recipe"
+    );
+    assert_eq!(
+        get["responses"]["404"]["content"]["application/json"]["schema"]["$ref"],
+        "#/components/schemas/ApiError"
+    );
+
+    let post = &value["paths"]["/recipes"]["post"];
+    assert_eq!(
+        post["requestBody"]["content"]["application/json"]["schema"]["$ref"],
+        "#/components/schemas/NewRecipe"
+    );
+    assert_eq!(
+        post["responses"]["201"]["content"]["application/json"]["schema"]["$ref"],
+        "#/components/schemas/Recipe"
+    );
+    // A response with no body carries no content at all.
+    assert!(post["responses"]["204"].get("content").is_none());
+
+    // Every `$ref` an operation emits resolves to a component that was exported.
+    let schemas = document.components.as_ref().unwrap();
+    for reference in collect_refs(&value["paths"]) {
+        let name = reference.trim_start_matches("#/components/schemas/");
+        assert!(
+            schemas.schemas.contains_key(name),
+            "operation $ref {reference:?} does not resolve"
+        );
+    }
+}
+
+fn collect_refs(value: &serde_json::Value) -> Vec<String> {
+    let mut refs = Vec::new();
+    fn walk(value: &serde_json::Value, refs: &mut Vec<String>) {
+        match value {
+            serde_json::Value::Object(map) => {
+                for (key, value) in map {
+                    match (key.as_str(), value.as_str()) {
+                        ("$ref", Some(reference)) => refs.push(reference.to_string()),
+                        _ => walk(value, refs),
+                    }
+                }
+            }
+            serde_json::Value::Array(items) => items.iter().for_each(|item| walk(item, refs)),
+            _ => {}
+        }
+    }
+    walk(value, &mut refs);
+    refs
+}
+
+/// Operation names are resolved by reproducing the JSON Schema exporter's naming, which
+/// disambiguates by module path only when two definitions share a name. This pins the reproduction
+/// against the real thing for both the plain and the disambiguated case.
+#[test]
+fn openapi_resolves_operations_against_disambiguated_component_names() {
+    let types = Types::default()
+        .register::<Recipe>()
+        .register::<other::Recipe>();
+
+    let document = OpenApi::default()
+        .operation(Operation::get("/a").response::<Recipe>(200, "outer"))
+        .operation(Operation::get("/b").response::<other::Recipe>(200, "inner"))
+        .export_document(&types, specta_serde::Format)
+        .expect("colliding names should still resolve");
+    let value = serde_json::to_value(&document).unwrap();
+
+    let schemas = document.components.as_ref().unwrap();
+    let refs = collect_refs(&value["paths"]);
+    assert_eq!(refs.len(), 2);
+    for reference in &refs {
+        let name = reference.trim_start_matches("#/components/schemas/");
+        assert!(
+            schemas.schemas.contains_key(name),
+            "disambiguated $ref {reference:?} does not resolve"
+        );
+    }
+    // Both were disambiguated, so the two operations cannot have landed on one component.
+    assert_ne!(refs[0], refs[1]);
+}
+
+#[test]
+fn openapi_rejects_operations_it_cannot_resolve() {
+    // A type absent from the exported collection.
+    let unregistered = OpenApi::default()
+        .operation(Operation::get("/a").response::<Recipe>(200, "ok"))
+        .export_document(
+            &Types::default().register::<ApiError>(),
+            specta_serde::Format,
+        )
+        .expect_err("an unexported type must not produce a dangling $ref");
+    assert!(unregistered.to_string().contains("Recipe"));
+
+    // The same method and path twice.
+    let duplicate = OpenApi::default()
+        .operation(Operation::get("/a").response::<Recipe>(200, "ok"))
+        .operation(Operation::get("/a").response::<Recipe>(200, "ok"))
+        .export_document(&recipe_types(), specta_serde::Format)
+        .expect_err("one method and path describes one operation");
+    assert!(duplicate.to_string().contains("duplicate operation"));
+
+    // An operation that says nothing about what it returns.
+    let empty = OpenApi::default()
+        .operation(Operation::get("/a"))
+        .export_document(&recipe_types(), specta_serde::Format)
+        .expect_err("an operation must declare at least one response");
+    assert!(empty.to_string().contains("declares no responses"));
+}
+
+/// Generic instantiations are exported one component per instantiation, with the arguments folded
+/// into the name and then sanitised. Operations resolve to those components by asking the exporter
+/// rather than reproducing the naming, so an `ApiResponse<T>`-shaped API is describable.
+#[test]
+fn openapi_resolves_generic_operation_types() {
+    let types = Types::default()
+        .register::<Wrapper<String>>()
+        .register::<Wrapper<Recipe>>();
+
+    let document = OpenApi::default()
+        .operation(Operation::get("/text").response::<Wrapper<String>>(200, "wrapped text"))
+        .operation(Operation::get("/recipe").response::<Wrapper<Recipe>>(200, "wrapped recipe"))
+        .export_document(&types, specta_serde::Format)
+        .expect("generic instantiations should resolve");
+    let value = serde_json::to_value(&document).unwrap();
+
+    // Each instantiation is its own component, so the two operations must not collapse onto one.
+    let text =
+        value["paths"]["/text"]["get"]["responses"]["200"]["content"]["application/json"]["schema"]
+            ["$ref"]
+            .as_str()
+            .unwrap()
+            .to_string();
+    let recipe = value["paths"]["/recipe"]["get"]["responses"]["200"]["content"]
+        ["application/json"]["schema"]["$ref"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert_ne!(text, recipe);
+
+    let schemas = document.components.as_ref().unwrap();
+    for reference in [&text, &recipe] {
+        let name = reference.trim_start_matches("#/components/schemas/");
+        assert!(
+            schemas.schemas.contains_key(name),
+            "generic $ref {reference:?} does not resolve"
+        );
+    }
+}
+
+/// The probe used to ask the exporter for component names must not appear in the output, nor change
+/// what the document would otherwise contain.
+#[test]
+fn openapi_resolution_probe_does_not_leak_into_the_document() {
+    let types = recipe_types();
+    let with_operations = OpenApi::default()
+        .operation(Operation::get("/recipes/{slug}").response::<Recipe>(200, "The recipe"))
+        .export_document(&types, specta_serde::Format)
+        .expect("operations should export");
+    let without_operations = OpenApi::default()
+        .export_document(&types, specta_serde::Format)
+        .expect("types should export");
+
+    let components = with_operations.components.as_ref().unwrap();
+    assert!(
+        components
+            .schemas
+            .keys()
+            .all(|name| !name.contains("probe")),
+        "the probe leaked into the components"
+    );
+    assert_eq!(
+        serde_json::to_value(&components).unwrap(),
+        serde_json::to_value(without_operations.components.as_ref().unwrap()).unwrap(),
+        "describing operations changed the exported components"
     );
 }


### PR DESCRIPTION
Closes half of #31. #530 fills `components.schemas` and leaves `paths` empty, so the document describes the types an API speaks but not the API. This adds the other half:

```rust
OpenApi::default()
    .operation(
        Operation::get("/recipes/{slug}")
            .path_param("slug")
            .response::<Recipe>(200, "The recipe")
            .response::<ApiError>(404, "No such recipe"),
    )
    .export(&types, specta_serde::Format)
```

Bodies are declared as types rather than names, so the paths and the schemas can't drift apart.

**Responses are stated, not inferred.** This is your `if header_value { (OK, Json(Ok)) } else { (CONFLICT, Json(Conflict)) }` case: there's no single Rust return type to recover both bodies from. It's not hypothetical either — vegify's own handlers return `Result<Json<Value>, AppError>`, so inference would recover nothing from them. Declaring per status is what works today; inferring the easy handlers can sit on top of this later, since it would produce these same `Operation`s.

**On resolving a type to its component.** That name is a property of the collection, not the type — module-path disambiguation on collisions, generic arguments folded in, then sanitising. I started out reproducing `definition_key`, which worked but meant a copy of your internals that was free to drift from them, and it couldn't do generics without copying `datatype_key` and `resolve_generics` too. So it asks instead: a probe type holding one field per referenced type is exported alongside the real ones, and the `$ref` you emit for each field is the answer. The probe is dropped from the components afterwards. Nothing is reproduced, generics work, and there's nothing left that can drift. If you'd rather expose the naming directly and have this call it, that's an easy swap and I'm happy to do it — the probe is only there because the mapping isn't reachable from outside.

Proven on vegify's real API: 17 paths, 34 schemas, 18 `$ref`s, none dangling, and the document round-trips through `openapiv3`'s parser.

Tests cover operations lowering into paths, generic instantiations resolving to distinct components, resolution against module-path-disambiguated names, that the probe doesn't leak or change the components (byte-identical with and without operations), and the rejections: an unregistered type, a duplicate method+path, an operation with no responses.

Checks: `fmt`, `clippy --all-features`, `test --all-features`, `build --all --no-default-features` all pass.

Entirely your call on the shape here — happy to cut it down or take it another way.