### PR TITLE
Fix parsing unrelated attribute expressions

### DIFF
--- a/specta-macros/src/utils.rs
+++ b/specta-macros/src/utils.rs
@@ -1,4 +1,4 @@
-use proc_macro2::Span;
+use proc_macro2::{Span, TokenTree};
 use quote::ToTokens;
 use syn::{
     Expr, Ident, Lit, Meta, Path, Result, Token, Type, TypePath,
@@ -228,8 +228,13 @@ impl Parse for NestedAttributeList {
                 let fork = input.fork();
                 let _ = fork.call(Ident::parse_any)?;
 
-                if fork.peek(Token![::]) {
-                    let _ignored: syn::Expr = input.parse()?;
+                if fork.peek(Token![::])
+                    || !(fork.is_empty()
+                        || fork.peek(Paren)
+                        || fork.peek(Token![=])
+                        || fork.peek(Token![,]))
+                {
+                    skip_unstructured_argument(input)?;
                 } else {
                     let key = input.call(Ident::parse_any)?;
                     let key_span = key.span();
@@ -255,7 +260,7 @@ impl Parse for NestedAttributeList {
                     });
                 }
             } else {
-                let _ignored: syn::Expr = input.parse()?;
+                skip_unstructured_argument(input)?;
             }
 
             if input.peek(Token![,]) {
@@ -264,6 +269,13 @@ impl Parse for NestedAttributeList {
         }
         Ok(NestedAttributeList { attrs })
     }
+}
+
+fn skip_unstructured_argument(input: ParseStream) -> Result<()> {
+    while !input.is_empty() && !input.peek(Token![,]) {
+        let _ = input.parse::<TokenTree>()?;
+    }
+    Ok(())
 }
 
 /// pass all of the attributes into a single structure.
@@ -345,4 +357,50 @@ pub fn unraw_raw_ident(ident: &Ident) -> String {
 #[cfg(feature = "DO_NOT_USE_function")]
 pub fn format_fn_wrapper(function: &Ident) -> Ident {
     quote::format_ident!("__specta__fn__{}", function)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ignores_method_calls_in_unrelated_attributes() {
+        let input = syn::parse_str::<syn::DeriveInput>(
+            r#"
+                #[error("Circular dependency detected: {}", chain.join(" -> "))]
+                enum InheritanceError { CircularDependency { chain: Vec<String> } }
+            "#,
+        )
+        .expect("test input should parse");
+
+        let attrs = parse_attrs(&input.attrs).expect("unrelated attribute should remain parseable");
+        let argument_count = match attrs[0].value.as_ref() {
+            Some(AttributeValue::Attribute { attr, .. }) => attr.len(),
+            _ => usize::MAX,
+        };
+        assert_eq!(argument_count, 0);
+    }
+
+    #[test]
+    fn parses_structured_metadata_alongside_unstructured_arguments() {
+        let input = syn::parse_str::<syn::DeriveInput>(
+            r#"
+                #[error("Circular dependency detected: {}", chain.join(" -> "))]
+                #[serde(rename_all = "camelCase", untagged)]
+                enum InheritanceError { CircularDependency { chain: Vec<String> } }
+            "#,
+        )
+        .expect("test input should parse");
+
+        let mut attrs = parse_attrs(&input.attrs).expect("attributes should parse");
+        assert!(attrs.extract("serde", "untagged").is_some());
+        assert_eq!(
+            attrs
+                .extract("serde", "rename_all")
+                .expect("rename_all should be captured")
+                .parse_string()
+                .expect("rename_all should be a string"),
+            "camelCase"
+        );
+    }
 }

--- a/specta-macros/src/utils.rs
+++ b/specta-macros/src/utils.rs
@@ -218,11 +218,13 @@ impl AttrExtract for Vec<Attribute> {
 
 struct NestedAttributeList {
     attrs: Vec<Attribute>,
+    unstructured_argument: Option<Span>,
 }
 
 impl Parse for NestedAttributeList {
     fn parse(input: ParseStream) -> Result<Self> {
         let mut attrs = Vec::new();
+        let mut unstructured_argument = None;
         while !input.is_empty() {
             if input.peek(Ident::peek_any) {
                 let fork = input.fork();
@@ -234,6 +236,7 @@ impl Parse for NestedAttributeList {
                         || fork.peek(Token![=])
                         || fork.peek(Token![,]))
                 {
+                    unstructured_argument.get_or_insert(input.span());
                     skip_unstructured_argument(input)?;
                 } else {
                     let key = input.call(Ident::parse_any)?;
@@ -246,9 +249,13 @@ impl Parse for NestedAttributeList {
                             _ if input.peek(Paren) => {
                                 let content;
                                 syn::parenthesized!(content in input);
+                                let nested = content.parse::<NestedAttributeList>()?;
+                                if unstructured_argument.is_none() {
+                                    unstructured_argument = nested.unstructured_argument;
+                                }
                                 Some(AttributeValue::Attribute {
                                     span: key_span,
-                                    attr: content.parse::<NestedAttributeList>()?.attrs,
+                                    attr: nested.attrs,
                                 })
                             }
                             _ if input.peek(Token![=]) => {
@@ -260,6 +267,7 @@ impl Parse for NestedAttributeList {
                     });
                 }
             } else {
+                unstructured_argument.get_or_insert(input.span());
                 skip_unstructured_argument(input)?;
             }
 
@@ -267,7 +275,10 @@ impl Parse for NestedAttributeList {
                 input.parse::<Token![,]>()?;
             }
         }
-        Ok(NestedAttributeList { attrs })
+        Ok(NestedAttributeList {
+            attrs,
+            unstructured_argument,
+        })
     }
 }
 
@@ -318,9 +329,16 @@ pub fn parse_attrs_with_filter(
             }],
             Meta::List(meta) => {
                 let source = attr_name.clone();
-                let mut parsed: Vec<Attribute> =
-                    syn::parse2::<NestedAttributeList>(meta.tokens.clone())?.attrs;
-                for a in &mut parsed {
+                let mut parsed = syn::parse2::<NestedAttributeList>(meta.tokens.clone())?;
+                if source == "specta"
+                    && let Some(span) = parsed.unstructured_argument
+                {
+                    return Err(syn::Error::new(
+                        span,
+                        "specta: unsupported attribute syntax",
+                    ));
+                }
+                for a in &mut parsed.attrs {
                     a.source = source.clone();
                 }
                 vec![Attribute {
@@ -328,7 +346,7 @@ pub fn parse_attrs_with_filter(
                     key: ident.clone(),
                     value: Some(AttributeValue::Attribute {
                         span: ident.span(),
-                        attr: parsed,
+                        attr: parsed.attrs,
                     }),
                 }]
             }
@@ -402,5 +420,18 @@ mod tests {
                 .expect("rename_all should be a string"),
             "camelCase"
         );
+    }
+
+    #[test]
+    fn rejects_unstructured_specta_arguments() {
+        let input = syn::parse_str::<syn::DeriveInput>(
+            r#"
+                #[specta(collect = false, typo.missing)]
+                struct Invalid;
+            "#,
+        )
+        .expect("test input should parse");
+
+        assert!(parse_attrs(&input.attrs).is_err());
     }
 }

--- a/tests/tests/macro_thiserror_attrs.rs
+++ b/tests/tests/macro_thiserror_attrs.rs
@@ -1,0 +1,58 @@
+use serde::Serialize;
+use specta::{Type, datatype::DataType};
+
+#[derive(Debug, thiserror::Error, Serialize, Type)]
+#[specta(collect = false)]
+#[serde(rename_all = "camelCase", untagged)]
+enum InheritanceError {
+    #[error("Circular dependency detected: {}", chain.join(" -> "))]
+    CircularDependency {
+        #[specta(type = Vec<String>)]
+        chain: Vec<String>,
+    },
+
+    #[error(
+        "Maximum inheritance depth exceeded ({max_depth}): {}",
+        chain.join(" -> ")
+    )]
+    MaxDepthExceeded {
+        #[specta(type = i32)]
+        max_depth: i32,
+        #[specta(type = Vec<String>)]
+        chain: Vec<String>,
+    },
+}
+
+#[derive(Debug, thiserror::Error, Type)]
+#[specta(collect = false)]
+enum OrdinaryError {
+    #[error("ordinary error: {message}")]
+    Message { message: String },
+}
+
+#[test]
+fn thiserror_method_call_arguments_compile_and_serde_attributes_are_captured() {
+    let mut types = specta::Types::default();
+    InheritanceError::definition(&mut types);
+
+    let data_type = types
+        .into_unsorted_iter()
+        .find(|data_type| data_type.name == "InheritanceError")
+        .and_then(|data_type| data_type.ty.clone())
+        .expect("InheritanceError should be registered");
+    let untagged = match data_type {
+        DataType::Enum(data_type) => data_type
+            .attributes
+            .get_named_as::<bool>("serde:container:untagged")
+            .copied(),
+        _ => None,
+    };
+
+    assert_eq!(untagged, Some(true));
+}
+
+#[test]
+fn ordinary_thiserror_enum_still_compiles_with_specta() {
+    let mut types = specta::Types::default();
+    OrdinaryError::definition(&mut types);
+}

--- a/tests/tests/mod.rs
+++ b/tests/tests/mod.rs
@@ -27,6 +27,7 @@ mod macro_doc_attrs;
 mod macro_generic_variant_override;
 mod macro_repr_transparent_enum;
 mod macro_structured_deprecated;
+mod macro_thiserror_attrs;
 mod maybe_undefined;
 mod openapi;
 mod python;


### PR DESCRIPTION
## Summary

- keep unstructured arguments in unrelated list attributes opaque to Specta's metadata parser
- preserve structured Specta and Serde attribute extraction
- cover `thiserror` formatting arguments containing method calls and ordinary Specta + `thiserror` enums

## Minimal reproduction and attribution

The minimized enum needs only `specta::Type`, `thiserror::Error`, and a method call in an `#[error(...)]` formatting argument:

```rust
#[derive(Debug, thiserror::Error, specta::Type)]
enum Error {
    #[error("Circular dependency detected: {}", chain.join(" -> "))]
    CircularDependency { chain: Vec<String> },
}
```

The isolation matrix passed with `thiserror::Error` alone, `serde::Serialize` alone, `#[serde(untagged)]`, `specta::Type` alone, and `specta::Type + thiserror::Error` with a non-method formatting argument. It failed for `specta::Type + thiserror::Error` with `chain.join(...)`, both with and without Serde derive, Specta's Serde-capture feature, `#[serde(untagged)]`, and field `#[specta(type = ...)]` overrides.

## Root cause

`NestedAttributeList` structurally inspected every list-style attribute, including unrelated `thiserror` attributes. When an argument began with `chain.join(...)`, it consumed `chain` as a bare metadata key. That left the cursor on the `.` at the reported span, where the next expression parse failed (`expected an expression`, or the narrower Syn-feature diagnostic in the standalone reproduction).

The parser now recognizes an identifier as structured metadata only when the following token can validly continue that metadata form: `(`, `=`, `,`, or end-of-input. Other arguments are consumed opaquely as token trees up to the next top-level comma. Grouped tokens keep their internal commas, so valid unrelated Rust attribute syntax is left alone without enabling Syn's full expression parser or special-casing `thiserror`.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p specta-macros --all-targets --all-features -- -D warnings`
- `cargo test -p specta-macros --all-features`
- `cargo test -p specta-tests macro_thiserror_attrs`
- standalone feature matrix covering Specta derive, Serde derive/capture, untagged enums, field overrides, `thiserror`, and method/non-method arguments (all combinations pass after the fix)
- full `cargo test -p specta-tests`: 536 passed; 17 Java compilation checks could not run because this environment has no Java runtime

Clippy for the integration package is currently blocked by three pre-existing Rust 1.97 warnings in unchanged `specta/src/datatype/named.rs` and `specta/src/types.rs`; the changed macro crate passes with warnings denied.
