### PR TITLE
Avoid repeated semantic mapper spreads

### DIFF
--- a/specta-typescript/src/semantic.rs
+++ b/specta-typescript/src/semantic.rs
@@ -763,7 +763,7 @@ impl Configuration {
             DataType::Intersection(items) => {
                 let mut ty = items.clone();
                 let mut changed = false;
-                let parts = items
+                let mut parts = items
                     .iter()
                     .enumerate()
                     .filter_map(|(idx, item)| {
@@ -782,6 +782,8 @@ impl Configuration {
                         Some(runtime)
                     })
                     .collect::<Vec<_>>();
+
+                parts.dedup();
 
                 match parts.as_slice() {
                     [] => None,

--- a/tests/tests/semantic.rs
+++ b/tests/tests/semantic.rs
@@ -80,6 +80,20 @@ fn semantic_custom_transforms_snapshot_nested_runtime_expressions() {
 }
 
 #[test]
+fn semantic_intersection_deduplicates_identical_runtime_transforms() {
+    let semantic = semantic_config();
+    let mut types = Types::default();
+    let dt = SemanticPayload::definition(&mut types);
+    let intersection = DataType::Intersection(vec![dt.clone(), dt]);
+
+    let (_, runtime) = semantic
+        .apply_deserialize(&types, &intersection, "payload")
+        .expect("semantic transform should apply");
+
+    assert_eq!(runtime.matches("site:new URL(payload.site)").count(), 1);
+}
+
+#[test]
 fn semantic_lossless_numbers_snapshot_export_and_transforms() {
     let semantic = Configuration::empty()
         .enable_lossless_bigints()


### PR DESCRIPTION
## Summary
- deduplicate identical runtime mapper branches for semantic intersection types
- cover the generated mapper expression with a regression test

## Root cause
Serde alias/phase handling can produce intersection branches with the same nested semantic transform. The TypeScript semantic generator merged every branch with object spreads, repeating an identical expression and inflating command bindings.

## Validation
- `cargo test -p specta-tests --test test semantic_intersection_deduplicates_identical_runtime_transforms`