### PR TITLE
Prune identity semantic mappers

### DIFF
--- a/specta-typescript/src/semantic.rs
+++ b/specta-typescript/src/semantic.rs
@@ -488,9 +488,9 @@ impl Configuration {
     /// deeply nested for structs, tuples, lists, nullable values, and
     /// intersections.
     ///
-    /// If no rule or built-in remap matches, `None` is returned. If a rule
-    /// matches but the type shape does not need to change, `Some((None,
-    /// runtime_str))` is returned.
+    /// If the graph contains no runtime transform, `None` is returned, including
+    /// when rules or built-in remaps only change the exported TypeScript type.
+    /// Type-only changes are handled by [`Configuration::apply_types`].
     ///
     pub fn apply_serialize(
         &self,
@@ -506,6 +506,7 @@ impl Configuration {
             js_ident,
             &mut Vec::new(),
         )
+        .filter(|(_, runtime)| runtime != js_ident)
     }
 
     /// Scan a [`DataType`] tree applying deserialize-facing rules.
@@ -526,6 +527,7 @@ impl Configuration {
             js_ident,
             &mut Vec::new(),
         )
+        .filter(|(_, runtime)| runtime != js_ident)
     }
 
     fn apply_inner(
@@ -720,9 +722,13 @@ impl Configuration {
 
                 Some((
                     changed.then_some(DataType::Map(ty)),
-                    format!(
-                        "Object.fromEntries(Object.entries({js_ident}).map(([k,{item}])=>[k,{runtime}]))"
-                    ),
+                    if runtime == item {
+                        js_ident.to_owned()
+                    } else {
+                        format!(
+                            "Object.fromEntries(Object.entries({js_ident}).map(([k,{item}])=>[k,{runtime}]))"
+                        )
+                    },
                 ))
             }
             DataType::List(list) => {
@@ -743,7 +749,11 @@ impl Configuration {
                 }
                 Some((
                     changed.then_some(DataType::List(ty)),
-                    format!("{js_ident}.map({item}=>{runtime})"),
+                    if runtime == item {
+                        js_ident.to_owned()
+                    } else {
+                        format!("{js_ident}.map({item}=>{runtime})")
+                    },
                 ))
             }
             DataType::Nullable(inner) => {
@@ -757,7 +767,11 @@ impl Configuration {
                 )?;
                 Some((
                     next_ty.map(|dt| DataType::Nullable(Box::new(dt))),
-                    format!("{js_ident}==null?{js_ident}:{runtime}"),
+                    if runtime == js_ident {
+                        js_ident.to_owned()
+                    } else {
+                        format!("{js_ident}==null?{js_ident}:{runtime}")
+                    },
                 ))
             }
             DataType::Intersection(items) => {

--- a/specta-typescript/src/semantic.rs
+++ b/specta-typescript/src/semantic.rs
@@ -488,9 +488,10 @@ impl Configuration {
     /// deeply nested for structs, tuples, lists, nullable values, and
     /// intersections.
     ///
-    /// If the graph contains no runtime transform, `None` is returned, including
-    /// when rules or built-in remaps only change the exported TypeScript type.
-    /// Type-only changes are handled by [`Configuration::apply_types`].
+    /// If a registered graph contains no runtime transform, `None` is returned;
+    /// its type-only changes are handled by [`Configuration::apply_types`]. For
+    /// inline inputs, a type-only result is retained with an identity runtime
+    /// expression because there is no registered type for `apply_types` to rewrite.
     ///
     pub fn apply_serialize(
         &self,
@@ -506,7 +507,7 @@ impl Configuration {
             js_ident,
             &mut Vec::new(),
         )
-        .filter(|(_, runtime)| runtime != js_ident)
+        .filter(|(next_ty, runtime)| next_ty.is_some() || runtime != js_ident)
     }
 
     /// Scan a [`DataType`] tree applying deserialize-facing rules.
@@ -527,7 +528,7 @@ impl Configuration {
             js_ident,
             &mut Vec::new(),
         )
-        .filter(|(_, runtime)| runtime != js_ident)
+        .filter(|(next_ty, runtime)| next_ty.is_some() || runtime != js_ident)
     }
 
     fn apply_inner(

--- a/specta-typescript/src/semantic.rs
+++ b/specta-typescript/src/semantic.rs
@@ -499,15 +499,15 @@ impl Configuration {
         dt: &DataType,
         js_ident: &str,
     ) -> Option<(Option<DataType>, String)> {
-        self.apply_inner(
+        let result = self.apply_inner(
             |rule| &rule.serialize,
             serialize_bigint,
             types,
             dt,
             js_ident,
             &mut Vec::new(),
-        )
-        .filter(|(next_ty, runtime)| next_ty.is_some() || runtime != js_ident)
+        );
+        prune_identity_root(types, dt, js_ident, result)
     }
 
     /// Scan a [`DataType`] tree applying deserialize-facing rules.
@@ -520,15 +520,15 @@ impl Configuration {
         dt: &DataType,
         js_ident: &str,
     ) -> Option<(Option<DataType>, String)> {
-        self.apply_inner(
+        let result = self.apply_inner(
             |rule| &rule.deserialize,
             deserialize_bigint,
             types,
             dt,
             js_ident,
             &mut Vec::new(),
-        )
-        .filter(|(next_ty, runtime)| next_ty.is_some() || runtime != js_ident)
+        );
+        prune_identity_root(types, dt, js_ident, result)
     }
 
     fn apply_inner(
@@ -894,6 +894,22 @@ impl Configuration {
             Some((Some(remapped), runtime))
         }
     }
+}
+
+fn prune_identity_root(
+    types: &Types,
+    dt: &DataType,
+    js_ident: &str,
+    result: Option<(Option<DataType>, String)>,
+) -> Option<(Option<DataType>, String)> {
+    let registered_root = matches!(
+        dt,
+        DataType::Reference(Reference::Named(reference))
+            if !matches!(reference.inner, NamedReferenceType::Inline { .. })
+                && types.get(reference).is_some()
+    );
+
+    result.filter(|(next_ty, runtime)| runtime != js_ident || next_ty.is_some() && !registered_root)
 }
 
 fn is_lossless_bigint_primitive(dt: &DataType) -> bool {

--- a/specta-typescript/src/semantic.rs
+++ b/specta-typescript/src/semantic.rs
@@ -906,7 +906,7 @@ fn prune_identity_root(
         dt,
         DataType::Reference(Reference::Named(reference))
             if !matches!(reference.inner, NamedReferenceType::Inline { .. })
-                && types.get(reference).is_some()
+                && types.get(reference).is_some_and(|ndt| ndt.ty.is_some())
     );
 
     result.filter(|(next_ty, runtime)| {

--- a/specta-typescript/src/semantic.rs
+++ b/specta-typescript/src/semantic.rs
@@ -909,7 +909,35 @@ fn prune_identity_root(
                 && types.get(reference).is_some()
     );
 
-    result.filter(|(next_ty, runtime)| runtime != js_ident || next_ty.is_some() && !registered_root)
+    result.filter(|(next_ty, runtime)| {
+        runtime != js_ident
+            || next_ty
+                .as_ref()
+                .is_some_and(|next_ty| !registered_root || registered_generics_changed(dt, next_ty))
+    })
+}
+
+fn registered_generics_changed(dt: &DataType, next_ty: &DataType) -> bool {
+    let (
+        DataType::Reference(Reference::Named(source)),
+        DataType::Reference(Reference::Named(remapped)),
+    ) = (dt, next_ty)
+    else {
+        return false;
+    };
+    let (
+        NamedReferenceType::Reference {
+            generics: source, ..
+        },
+        NamedReferenceType::Reference {
+            generics: remapped, ..
+        },
+    ) = (&source.inner, &remapped.inner)
+    else {
+        return false;
+    };
+
+    source != remapped
 }
 
 fn is_lossless_bigint_primitive(dt: &DataType) -> bool {

--- a/tests/tests/semantic.rs
+++ b/tests/tests/semantic.rs
@@ -227,6 +227,27 @@ fn semantic_registered_identity_rule_does_not_emit_a_runtime_transform() {
 }
 
 #[test]
+fn semantic_definitionless_identity_rule_retains_its_type_remap() {
+    let semantic = identity_semantic_config();
+    let mut types = Types::default();
+    let dt = Website::definition(&mut types);
+    let types = types.map(|mut ndt| {
+        ndt.ty = None;
+        ndt
+    });
+
+    for transform in [
+        semantic.apply_serialize(&types, &dt, "payload"),
+        semantic.apply_deserialize(&types, &dt, "payload"),
+    ] {
+        let (remapped, runtime) =
+            transform.expect("definitionless rules must retain their type remap");
+        assert!(remapped.is_some());
+        assert_eq!(runtime, "payload");
+    }
+}
+
+#[test]
 fn semantic_registered_generic_retains_identity_use_site_remaps() {
     let semantic = Configuration::empty().enable_lossless_floats();
     let mut types = Types::default();

--- a/tests/tests/semantic.rs
+++ b/tests/tests/semantic.rs
@@ -33,6 +33,29 @@ struct CombinedPayload {
     nested: Vec<Option<Website>>,
 }
 
+#[derive(Type)]
+#[specta(collect = false)]
+struct StructWithF64 {
+    value: f64,
+}
+
+#[derive(Type)]
+#[specta(collect = false)]
+struct IdentityFloatPayload {
+    value: f64,
+    nested: Option<StructWithF64>,
+    values: Vec<f64>,
+}
+
+#[derive(Type)]
+#[specta(collect = false)]
+struct MixedIdentityPayload {
+    value: f64,
+    nested: Option<StructWithF64>,
+    values: Vec<f64>,
+    site: Website,
+}
+
 fn semantic_config() -> Configuration {
     Configuration::empty().define::<Website>(
         |_| define("URL").into(),
@@ -107,10 +130,7 @@ fn semantic_lossless_numbers_snapshot_export_and_transforms() {
         .expect("lossless semantic numbers should export");
 
     insta::assert_snapshot!("semantic-lossless-numbers-export", rendered);
-    insta::assert_snapshot!(
-        "semantic-lossless-numbers-serialize-transform",
-        transformed_snapshot(&types, semantic.apply_serialize(&types, &dt, "payload"),)
-    );
+    assert_eq!(semantic.apply_serialize(&types, &dt, "payload"), None);
     insta::assert_snapshot!(
         "semantic-lossless-numbers-deserialize-transform",
         transformed_snapshot(&types, semantic.apply_deserialize(&types, &dt, "payload"),)
@@ -136,4 +156,35 @@ fn semantic_custom_rules_compose_with_lossless_builtin_remaps() {
         "semantic-composed-deserialize-transform",
         transformed_snapshot(&types, semantic.apply_deserialize(&types, &dt, "payload"),)
     );
+}
+
+#[test]
+fn semantic_lossless_floats_do_not_emit_identity_runtime_transforms() {
+    let semantic = Configuration::default().enable_lossless_floats();
+    let mut types = Types::default();
+
+    for dt in [
+        f64::definition(&mut types),
+        IdentityFloatPayload::definition(&mut types),
+    ] {
+        assert_eq!(semantic.apply_serialize(&types, &dt, "payload"), None);
+        assert_eq!(semantic.apply_deserialize(&types, &dt, "payload"), None);
+    }
+}
+
+#[test]
+fn semantic_identity_descendants_are_pruned_from_real_runtime_transforms() {
+    let semantic = semantic_config().enable_lossless_floats();
+    let mut types = Types::default();
+    let dt = MixedIdentityPayload::definition(&mut types);
+
+    let (_, serialize) = semantic
+        .apply_serialize(&types, &dt, "payload")
+        .expect("Website serialization should require a runtime transform");
+    assert_eq!(serialize, "({...payload,site:payload.site.toString()})");
+
+    let (_, deserialize) = semantic
+        .apply_deserialize(&types, &dt, "payload")
+        .expect("Website deserialization should require a runtime transform");
+    assert_eq!(deserialize, "({...payload,site:new URL(payload.site)})");
 }

--- a/tests/tests/semantic.rs
+++ b/tests/tests/semantic.rs
@@ -56,6 +56,12 @@ struct MixedIdentityPayload {
     site: Website,
 }
 
+#[derive(Type)]
+#[specta(collect = false)]
+struct Wrapper<T> {
+    value: T,
+}
+
 fn semantic_config() -> Configuration {
     Configuration::empty().define::<Website>(
         |_| define("URL").into(),
@@ -218,6 +224,23 @@ fn semantic_registered_identity_rule_does_not_emit_a_runtime_transform() {
 
     assert_eq!(semantic.apply_serialize(&types, &dt, "payload"), None);
     assert_eq!(semantic.apply_deserialize(&types, &dt, "payload"), None);
+}
+
+#[test]
+fn semantic_registered_generic_retains_identity_use_site_remaps() {
+    let semantic = Configuration::empty().enable_lossless_floats();
+    let mut types = Types::default();
+    let dt = Wrapper::<f64>::definition(&mut types);
+
+    for transform in [
+        semantic.apply_serialize(&types, &dt, "payload"),
+        semantic.apply_deserialize(&types, &dt, "payload"),
+    ] {
+        let (remapped, runtime) =
+            transform.expect("registered generic arguments must retain their type remap");
+        assert!(remapped.is_some());
+        assert_eq!(runtime, "payload");
+    }
 }
 
 #[test]

--- a/tests/tests/semantic.rs
+++ b/tests/tests/semantic.rs
@@ -64,6 +64,14 @@ fn semantic_config() -> Configuration {
     )
 }
 
+fn identity_semantic_config() -> Configuration {
+    Configuration::empty().define::<Website>(
+        |_| define("URL").into(),
+        Some(Transform::identity()),
+        Some(Transform::identity()),
+    )
+}
+
 fn transformed_snapshot(types: &Types, transform: Option<(Option<DataType>, String)>) -> String {
     let (ty, runtime) = transform.expect("semantic transform should apply");
     let ty = ty
@@ -172,8 +180,9 @@ fn semantic_lossless_floats_do_not_emit_identity_runtime_transforms() {
             semantic.apply_serialize(&types, &inline, "payload"),
             semantic.apply_deserialize(&types, &inline, "payload"),
         ] {
-            let (remapped, runtime) =
-                transform.expect("inline floats must retain their type remap");
+            let (remapped, runtime) = transform.unwrap_or_else(|| {
+                panic!("inline floats must retain their type remap: {inline:?}")
+            });
             assert!(remapped.is_some());
             assert_eq!(runtime, "payload");
         }
@@ -199,6 +208,16 @@ fn semantic_inline_identity_bigint_retains_its_type_remap() {
         .expect("inline bigints must retain their type remap");
     assert!(remapped.is_some());
     assert_eq!(runtime, "payload");
+}
+
+#[test]
+fn semantic_registered_identity_rule_does_not_emit_a_runtime_transform() {
+    let semantic = identity_semantic_config();
+    let mut types = Types::default();
+    let dt = Website::definition(&mut types);
+
+    assert_eq!(semantic.apply_serialize(&types, &dt, "payload"), None);
+    assert_eq!(semantic.apply_deserialize(&types, &dt, "payload"), None);
 }
 
 #[test]

--- a/tests/tests/semantic.rs
+++ b/tests/tests/semantic.rs
@@ -163,13 +163,42 @@ fn semantic_lossless_floats_do_not_emit_identity_runtime_transforms() {
     let semantic = Configuration::default().enable_lossless_floats();
     let mut types = Types::default();
 
-    for dt in [
+    for inline in [
         f64::definition(&mut types),
-        IdentityFloatPayload::definition(&mut types),
+        Vec::<f64>::definition(&mut types),
+        Option::<f64>::definition(&mut types),
     ] {
-        assert_eq!(semantic.apply_serialize(&types, &dt, "payload"), None);
-        assert_eq!(semantic.apply_deserialize(&types, &dt, "payload"), None);
+        for transform in [
+            semantic.apply_serialize(&types, &inline, "payload"),
+            semantic.apply_deserialize(&types, &inline, "payload"),
+        ] {
+            let (remapped, runtime) =
+                transform.expect("inline floats must retain their type remap");
+            assert!(remapped.is_some());
+            assert_eq!(runtime, "payload");
+        }
     }
+
+    let registered = IdentityFloatPayload::definition(&mut types);
+    for transform in [
+        semantic.apply_serialize(&types, &registered, "payload"),
+        semantic.apply_deserialize(&types, &registered, "payload"),
+    ] {
+        assert_eq!(transform, None);
+    }
+}
+
+#[test]
+fn semantic_inline_identity_bigint_retains_its_type_remap() {
+    let semantic = Configuration::empty().enable_lossless_bigints();
+    let mut types = Types::default();
+    let dt = u64::definition(&mut types);
+
+    let (remapped, runtime) = semantic
+        .apply_serialize(&types, &dt, "payload")
+        .expect("inline bigints must retain their type remap");
+    assert!(remapped.is_some());
+    assert_eq!(runtime, "payload");
 }
 
 #[test]

--- a/tests/tests/snapshots/test__semantic__semantic-lossless-numbers-deserialize-transform.snap
+++ b/tests/tests/snapshots/test__semantic__semantic-lossless-numbers-deserialize-transform.snap
@@ -3,4 +3,4 @@ source: tests/tests/semantic.rs
 expression: "transformed_snapshot(&types,\nsemantic.apply_deserialize(&types, &dt, \"payload\"),)"
 ---
 type: <unchanged>
-runtime: ({...payload,id:BigInt(payload.id),signed:BigInt(payload.signed),scores:payload.scores.map(i=>i),maybe_score:payload.maybe_score==null?payload.maybe_score:payload.maybe_score})
+runtime: ({...payload,id:BigInt(payload.id),signed:BigInt(payload.signed)})

--- a/tests/tests/snapshots/test__semantic__semantic-lossless-numbers-serialize-transform.snap
+++ b/tests/tests/snapshots/test__semantic__semantic-lossless-numbers-serialize-transform.snap
@@ -1,6 +1,0 @@
----
-source: tests/tests/semantic.rs
-expression: "transformed_snapshot(&types,\nsemantic.apply_serialize(&types, &dt, \"payload\"),)"
----
-type: <unchanged>
-runtime: ({...payload,scores:payload.scores.map(i=>i),maybe_score:payload.maybe_score==null?payload.maybe_score:payload.maybe_score})


### PR DESCRIPTION
## What changed

- prune identity-only semantic transforms before exposing serialize/deserialize mappers
- avoid emitting list, map, and nullable traversal when their descendants have no runtime conversion
- preserve genuine transforms in mixed graphs, including BigInt and custom URL conversions
- add regressions for direct floats, optional nested structs, float arrays, mixed graphs, and both directions

## Root cause

Lossless float remapping changes Specta's exported type representation but not the JavaScript runtime value. Container traversal treated that type-only result as a runtime transform and generated identity `.map(...)` and null-check expressions, which caused downstream command generators such as Tauri Specta to wrap otherwise unchanged results in `.then(...)` mappers.

The canonical Specta APIs now return `None` for fully identity runtime graphs while retaining type-only remapping through `Configuration::apply_types`. Consumers therefore require no paired workaround.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p specta-typescript`
- `cargo test -p specta-tests semantic`
- `cargo clippy -p specta-typescript -- -D warnings`

Workspace test-target Clippy was also attempted with warnings denied; it reaches unrelated pre-existing warnings in `maybe_undefined.rs`, `openapi.rs`, and `serde_validate_coverage.rs`.
