### PR TITLE
Simplify optional serde alias types

### DIFF
--- a/specta-typescript/src/primitives.rs
+++ b/specta-typescript/src/primitives.rs
@@ -3170,9 +3170,11 @@ fn enum_dt(
 /// intersection of unions. The latter distributes into one union member for
 /// every combination of aliased fields, which quickly reaches TS2590.
 ///
-/// The mapped type retains the original semantics: each required field must
-/// use exactly one accepted spelling, optional fields may be omitted, and two
-/// spellings of the same field cannot be supplied together.
+/// The mapped type retains the original semantics for required fields: each
+/// must use exactly one accepted spelling. Fully optional alias groups render
+/// as their plain object intersection instead. TypeScript cannot retain their
+/// duplicate-key rejection without forcing consumers to expand an exponential
+/// union, while serde's optional/omitted behavior remains represented.
 fn alias_field_union_dt(
     s: &mut String,
     exporter: &Exporter,
@@ -3183,6 +3185,7 @@ fn alias_field_union_dt(
     generics: &[(GenericReference, DataType)],
 ) -> Result<(), Error> {
     let mut fields = Vec::with_capacity(e.variants.len());
+    let mut all_optional = true;
 
     for (name, variant) in active_variants(e) {
         let mut variant = (*variant).clone();
@@ -3196,6 +3199,9 @@ fn alias_field_union_dt(
             named
                 .fields
                 .retain(|(_, field)| !field.attributes.contains_key(FIELD_ALIAS_EXCLUSION_MARKER));
+            all_optional &= named.fields.iter().all(|(_, field)| field.optional);
+        } else {
+            all_optional = false;
         }
 
         let mut variant_location = location.clone();
@@ -3216,6 +3222,11 @@ fn alias_field_union_dt(
     }
 
     let source = fields.join(" & ");
+    if all_optional {
+        s.push_str(&source);
+        return Ok(());
+    }
+
     s.push_str("((");
     s.push_str(&source);
     s.push_str(") extends infer T extends object ? { [K in keyof T]: { [P in keyof T as P extends K ? P : never]: T[P] } & { [P in keyof T as P extends K ? never : P]?: never } }[keyof T] & object : never)");

--- a/tests/examples/zod_typecheck.rs
+++ b/tests/examples/zod_typecheck.rs
@@ -196,6 +196,79 @@ struct OptionalAlias {
 }
 
 #[derive(Type, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CanonicalModelPricing {
+    #[serde(default, alias = "input_cost")]
+    input_cost: Option<f64>,
+    #[serde(default, alias = "output_cost")]
+    output_cost: Option<f64>,
+    #[serde(default, alias = "cache_read_cost")]
+    cache_read_cost: Option<f64>,
+    #[serde(default, alias = "cache_write_cost")]
+    cache_write_cost: Option<f64>,
+    #[serde(default, alias = "image_cost")]
+    image_cost: Option<f64>,
+    #[serde(default, alias = "audio_cost")]
+    audio_cost: Option<f64>,
+    #[serde(default, alias = "request_cost")]
+    request_cost: Option<f64>,
+    #[serde(default, alias = "training_cost")]
+    training_cost: Option<f64>,
+    #[serde(default, alias = "batch_discount")]
+    batch_discount: Option<f64>,
+    #[serde(default, alias = "storage_cost")]
+    storage_cost: Option<f64>,
+    #[serde(default, alias = "embedding_cost")]
+    embedding_cost: Option<f64>,
+    #[serde(default, alias = "search_cost")]
+    search_cost: Option<f64>,
+    #[serde(default, alias = "reasoning_cost")]
+    reasoning_cost: Option<f64>,
+    #[serde(default, alias = "minimum_cost")]
+    minimum_cost: Option<f64>,
+    #[serde(default, alias = "currency_code")]
+    currency_code: Option<String>,
+    #[serde(default, alias = "billing_unit")]
+    billing_unit: Option<String>,
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CatalogProvider {
+    #[serde(default, alias = "display_name")]
+    display_name: Option<String>,
+    #[serde(default, alias = "base_url")]
+    base_url: Option<String>,
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CatalogCapability {
+    #[serde(default, alias = "supports_tools")]
+    supports_tools: Option<bool>,
+    #[serde(default, alias = "context_window")]
+    context_window: Option<u32>,
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CatalogEntry {
+    #[serde(default, alias = "model_id")]
+    model_id: Option<String>,
+    #[serde(default, alias = "provider_info")]
+    provider_info: Option<CatalogProvider>,
+    #[serde(default, alias = "model_pricing")]
+    model_pricing: Option<CanonicalModelPricing>,
+    #[serde(default, alias = "model_capability")]
+    model_capability: Option<CatalogCapability>,
+}
+
+#[derive(Type, Serialize, Deserialize)]
+struct CatalogResponse {
+    entries: Vec<CatalogEntry>,
+}
+
+#[derive(Type, Serialize, Deserialize)]
 struct Pick {
     value: String,
 }
@@ -338,6 +411,11 @@ fn main() {
     let alias_types = Types::default()
         .register::<AliasHeavy>()
         .register::<OptionalAlias>()
+        .register::<CatalogResponse>()
+        .register::<CatalogEntry>()
+        .register::<CatalogProvider>()
+        .register::<CanonicalModelPricing>()
+        .register::<CatalogCapability>()
         .register::<Pick>();
     Typescript::default()
         .export_to(

--- a/tests/zod-typecheck/serde-aliases.test.ts
+++ b/tests/zod-typecheck/serde-aliases.test.ts
@@ -1,4 +1,4 @@
-import type { AliasHeavy, OptionalAlias } from "./generated/serde-aliases";
+import type { AliasHeavy, CatalogEntry, CatalogResponse, OptionalAlias } from "./generated/serde-aliases";
 
 function readFirst<T extends AliasHeavy>(value: T) {
   return value.first ?? value.first_old;
@@ -20,7 +20,6 @@ const missing: AliasHeavy = {};
 const absentOptional: OptionalAlias = {};
 const canonicalOptional: OptionalAlias = { value: "" };
 const aliasOptional: OptionalAlias = { value_old: "" };
-// @ts-expect-error serde rejects duplicate spellings for an optional field too.
 const duplicateOptional: OptionalAlias = { value: "", value_old: "" };
 // @ts-expect-error serde requires an object even when every field is optional.
 const undefinedOptional: OptionalAlias = undefined;
@@ -34,3 +33,31 @@ void canonicalOptional;
 void aliasOptional;
 void duplicateOptional;
 void undefinedOptional;
+
+declare const raw: CatalogResponse;
+
+const mappedEntries = raw.entries.map(entry => ({
+  id: entry.modelId ?? entry.model_id,
+  inputCost: entry.modelPricing?.inputCost ?? entry.modelPricing?.input_cost,
+  provider: entry.providerInfo?.displayName ?? entry.providerInfo?.display_name,
+  tools: entry.modelCapability?.supportsTools ?? entry.modelCapability?.supports_tools,
+}));
+
+function consumeEntry(entry: Pick<CatalogEntry, "modelId" | "modelPricing">) {
+  return entry.modelPricing?.outputCost;
+}
+
+const structurallyAssigned: { modelId?: string | null } = raw.entries[0];
+
+type QueryResult<T> = { data: T };
+function consumeQuery<T extends { entries: CatalogEntry[] }>(query: QueryResult<T>) {
+  return query.data.entries.map(consumeEntry);
+}
+
+const queryResult: QueryResult<CatalogResponse> = { data: raw };
+const queriedEntries = consumeQuery(queryResult);
+
+void duplicateOptional;
+void mappedEntries;
+void structurallyAssigned;
+void queriedEntries;


### PR DESCRIPTION
## What changed

- emit fully optional serde alias groups as plain intersections of optional properties
- keep the exact mapped XOR representation for required alias groups
- add a Rust-to-generated-TypeScript catalog fixture with alias-heavy nested pricing, provider, and capability types
- compile ordinary array mapping, nested property access, structural/Pick consumption, and a generic query-result wrapper

## Root cause

The deferred mapped XOR introduced in #553 avoids eagerly spelling out the exponential alias union, but intersecting many optional mapped XOR groups still forces TypeScript to instantiate a prohibitively deep type during ordinary consumer operations. The regression fixture fails with TS2589 on a nested property read using the pre-fix emitter.

For a fully optional alias group, serde permits omission and accepts either spelling. Emitting the accepted optional properties directly preserves those useful semantics and keeps the generated type tractable. TypeScript duplicate-key rejection is intentionally relaxed for optional aliases because expressing it recreates the exponential union pressure. Required aliases retain exact one-of semantics and duplicate-key rejection.

This is independent of #555's runtime semantic mapper pruning and is therefore a focused follow-up.

## Validation

- generated fixture + TypeScript 5.9.3 compile
- `cargo test -p specta-tests serde_flatten_option`
- `cargo test -p specta-typescript`
- `cargo clippy -p specta-typescript -- -D warnings`
- `cargo fmt --all`
