### PR TITLE
Simplify nested optional serde aliases

### DIFF
--- a/specta-serde/src/lib.rs
+++ b/specta-serde/src/lib.rs
@@ -875,7 +875,9 @@ fn rewrite_datatype_for_phase(
         split_types,
         container_name,
         &mut HashSet::new(),
-    )
+    )?;
+    defer_fully_optional_alias_unions(ty);
+    Ok(())
 }
 
 fn rewrite_datatype_for_phase_inner(
@@ -2173,6 +2175,133 @@ fn alias_union_is_fully_exclusive(enm: &Enum) -> bool {
         })
 }
 
+/// Restores symbolic lowering for optional aliases after every enclosing serde
+/// rewrite has finished. Flatten and enum lowering can move alias unions into
+/// newly synthesized intersections after the local field pass that normally
+/// marks independent alias groups, so this must walk the final graph.
+fn defer_fully_optional_alias_unions(ty: &mut DataType) {
+    match ty {
+        DataType::Struct(strct) => {
+            if let Fields::Named(fields) = &mut strct.fields {
+                for (_, field) in &mut fields.fields {
+                    if let Some(ty) = &mut field.ty {
+                        defer_fully_optional_alias_unions(ty);
+                    }
+                }
+            } else if let Fields::Unnamed(fields) = &mut strct.fields {
+                for field in &mut fields.fields {
+                    if let Some(ty) = &mut field.ty {
+                        defer_fully_optional_alias_unions(ty);
+                    }
+                }
+            }
+        }
+        DataType::Enum(enm) => {
+            for (_, variant) in &mut enm.variants {
+                match &mut variant.fields {
+                    Fields::Named(fields) => {
+                        for (_, field) in &mut fields.fields {
+                            if let Some(ty) = &mut field.ty {
+                                defer_fully_optional_alias_unions(ty);
+                            }
+                        }
+                    }
+                    Fields::Unnamed(fields) => {
+                        for field in &mut fields.fields {
+                            if let Some(ty) = &mut field.ty {
+                                defer_fully_optional_alias_unions(ty);
+                            }
+                        }
+                    }
+                    Fields::Unit => {}
+                }
+            }
+
+            if enm.attributes.contains_key(ALIAS_UNION_MARKER)
+                && alias_union_is_fully_optional(enm)
+                && (alias_union_is_fully_exclusive(enm) || alias_union_has_no_exclusions(enm))
+            {
+                enm.attributes.insert(DEFERRED_ALIAS_UNION_MARKER, true);
+            }
+        }
+        DataType::Tuple(tuple) => {
+            for ty in &mut tuple.elements {
+                defer_fully_optional_alias_unions(ty);
+            }
+        }
+        DataType::List(list) => defer_fully_optional_alias_unions(&mut list.ty),
+        DataType::Map(map) => {
+            defer_fully_optional_alias_unions(map.key_ty_mut());
+            defer_fully_optional_alias_unions(map.value_ty_mut());
+        }
+        DataType::Intersection(types) => {
+            for ty in types {
+                defer_fully_optional_alias_unions(ty);
+            }
+        }
+        DataType::Nullable(inner) => defer_fully_optional_alias_unions(inner),
+        DataType::Reference(Reference::Named(reference)) => {
+            if let NamedReferenceType::Inline { dt, .. } = &mut reference.inner {
+                defer_fully_optional_alias_unions(dt);
+            }
+            for (_, ty) in named_reference_generics_mut(reference) {
+                defer_fully_optional_alias_unions(ty);
+            }
+        }
+        DataType::Reference(Reference::Opaque(_))
+        | DataType::Generic(_)
+        | DataType::Primitive(_) => {}
+    }
+}
+
+fn alias_union_is_fully_optional(enm: &Enum) -> bool {
+    !enm.variants.is_empty()
+        && enm.variants.iter().all(|(_, variant)| {
+            let Fields::Unnamed(fields) = &variant.fields else {
+                return false;
+            };
+            let [field] = fields.fields.as_slice() else {
+                return false;
+            };
+            let Some(DataType::Struct(strct)) = &field.ty else {
+                return false;
+            };
+            let Fields::Named(fields) = &strct.fields else {
+                return false;
+            };
+
+            fields
+                .fields
+                .iter()
+                .any(|(_, field)| !field.attributes.contains_key(ALIAS_EXCLUSION_MARKER))
+                && fields.fields.iter().all(|(_, field)| {
+                    field.attributes.contains_key(ALIAS_EXCLUSION_MARKER) || field.optional
+                })
+        })
+}
+
+fn alias_union_has_no_exclusions(enm: &Enum) -> bool {
+    enm.variants.iter().all(|(_, variant)| {
+        let Fields::Unnamed(fields) = &variant.fields else {
+            return false;
+        };
+        let [field] = fields.fields.as_slice() else {
+            return false;
+        };
+        let Some(DataType::Struct(strct)) = &field.ty else {
+            return false;
+        };
+        let Fields::Named(fields) = &strct.fields else {
+            return false;
+        };
+
+        fields
+            .fields
+            .iter()
+            .all(|(_, field)| !field.attributes.contains_key(ALIAS_EXCLUSION_MARKER))
+    })
+}
+
 fn field_has_aliases(field: &Field) -> bool {
     SerdeFieldAttrs::from_attributes(&field.attributes)
         .ok()
@@ -2743,8 +2872,8 @@ const CONDITIONAL_OMISSION_MARKER: &str = "specta_serde:conditional_omission";
 /// contextual flatten relaxation.
 const ALIAS_EXCLUSION_MARKER: &str = "specta_serde:alias_exclusion";
 const ALIAS_UNION_MARKER: &str = "specta_serde:alias_union";
-/// Marks independent alias unions that an exporter may preserve symbolically
-/// instead of distributing their enclosing intersection into a Cartesian union.
+/// Marks alias unions that an exporter may preserve symbolically instead of
+/// distributing their enclosing intersection into a Cartesian union.
 const DEFERRED_ALIAS_UNION_MARKER: &str = "specta_serde:deferred_alias_union";
 
 fn rewrite_enum_repr_for_phase(

--- a/tests/examples/zod_typecheck.rs
+++ b/tests/examples/zod_typecheck.rs
@@ -250,6 +250,125 @@ struct CatalogCapability {
     context_window: Option<u32>,
 }
 
+macro_rules! optional_alias_part {
+    ($name:ident, $field:ident: $ty:ty, $alias:literal) => {
+        #[derive(Type, Serialize, Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct $name {
+            #[serde(default, alias = $alias)]
+            $field: Option<$ty>,
+        }
+    };
+}
+
+optional_alias_part!(ThinkingEffort, effort_levels: Vec<String>, "effort_levels");
+optional_alias_part!(ThinkingReasoning, include_reasoning_in_response: bool, "include_reasoning_in_response");
+optional_alias_part!(ThinkingOutput, counts_against_output: bool, "counts_against_output");
+optional_alias_part!(ThinkingSummary, supports_summary: bool, "supports_summary");
+optional_alias_part!(ThinkingBudget, supports_budget: bool, "supports_budget");
+optional_alias_part!(ThinkingMinimum, minimum_effort: String, "minimum_effort");
+optional_alias_part!(ThinkingMaximum, maximum_effort: String, "maximum_effort");
+optional_alias_part!(ThinkingDefault, default_effort: String, "default_effort");
+optional_alias_part!(ThinkingFormat, summary_format: String, "summary_format");
+optional_alias_part!(ThinkingUnit, budget_unit: String, "budget_unit");
+optional_alias_part!(ThinkingTokens, reasoning_tokens: u32, "reasoning_tokens");
+optional_alias_part!(ThinkingVisible, visible_tokens: u32, "visible_tokens");
+optional_alias_part!(ThinkingStreaming, supports_streaming: bool, "supports_streaming");
+optional_alias_part!(ThinkingTraces, supports_traces: bool, "supports_traces");
+optional_alias_part!(ThinkingRedaction, supports_redaction: bool, "supports_redaction");
+optional_alias_part!(ThinkingEncryption, supports_encryption: bool, "supports_encryption");
+optional_alias_part!(ThinkingCache, caches_reasoning: bool, "caches_reasoning");
+optional_alias_part!(ThinkingParallel, supports_parallel: bool, "supports_parallel");
+optional_alias_part!(ThinkingToolUse, supports_tool_use: bool, "supports_tool_use");
+optional_alias_part!(ThinkingRetention, retention_days: u32, "retention_days");
+
+#[derive(Type, Serialize, Deserialize)]
+struct ThinkingConfig {
+    #[serde(flatten)]
+    effort: ThinkingEffort,
+    #[serde(flatten)]
+    reasoning: ThinkingReasoning,
+    #[serde(flatten)]
+    output: ThinkingOutput,
+    #[serde(flatten)]
+    summary: ThinkingSummary,
+    #[serde(flatten)]
+    budget: ThinkingBudget,
+    #[serde(flatten)]
+    minimum: ThinkingMinimum,
+    #[serde(flatten)]
+    maximum: ThinkingMaximum,
+    #[serde(flatten)]
+    default: ThinkingDefault,
+    #[serde(flatten)]
+    format: ThinkingFormat,
+    #[serde(flatten)]
+    unit: ThinkingUnit,
+    #[serde(flatten)]
+    tokens: ThinkingTokens,
+    #[serde(flatten)]
+    visible: ThinkingVisible,
+    #[serde(flatten)]
+    streaming: ThinkingStreaming,
+    #[serde(flatten)]
+    traces: ThinkingTraces,
+    #[serde(flatten)]
+    redaction: ThinkingRedaction,
+    #[serde(flatten)]
+    encryption: ThinkingEncryption,
+    #[serde(flatten)]
+    cache: ThinkingCache,
+    #[serde(flatten)]
+    parallel: ThinkingParallel,
+    #[serde(flatten)]
+    tool_use: ThinkingToolUse,
+    #[serde(flatten)]
+    retention: ThinkingRetention,
+}
+
+#[derive(Type, Serialize, Deserialize)]
+struct ExtensibleThinkingConfig {
+    #[serde(flatten)]
+    config: ThinkingConfig,
+    #[serde(flatten)]
+    extra: HashMap<String, String>,
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum CanonicalModelThinking {
+    Configured(ThinkingConfig),
+    Extensible(ExtensibleThinkingConfig),
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CatalogMetadata {
+    #[serde(default, alias = "display_label")]
+    display_label: Option<String>,
+    #[serde(default, alias = "release_stage")]
+    release_stage: Option<String>,
+    #[serde(default, alias = "documentation_url")]
+    documentation_url: Option<String>,
+    #[serde(default, alias = "deprecation_date")]
+    deprecation_date: Option<String>,
+    #[serde(flatten)]
+    extra: HashMap<String, String>,
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CatalogLimits {
+    #[serde(default, alias = "max_input_tokens")]
+    max_input_tokens: Option<u32>,
+    #[serde(default, alias = "max_output_tokens")]
+    max_output_tokens: Option<u32>,
+    #[serde(default, alias = "max_images")]
+    max_images: Option<u32>,
+    #[serde(default, alias = "max_tools")]
+    max_tools: Option<u32>,
+}
+
 #[derive(Type, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct CatalogEntry {
@@ -261,6 +380,12 @@ struct CatalogEntry {
     model_pricing: Option<CanonicalModelPricing>,
     #[serde(default, alias = "model_capability")]
     model_capability: Option<CatalogCapability>,
+    #[serde(default, alias = "model_thinking")]
+    model_thinking: Option<CanonicalModelThinking>,
+    #[serde(default, alias = "model_limits")]
+    model_limits: Option<CatalogLimits>,
+    #[serde(default, alias = "model_metadata")]
+    model_metadata: Option<CatalogMetadata>,
 }
 
 #[derive(Type, Serialize, Deserialize)]
@@ -416,6 +541,9 @@ fn main() {
         .register::<CatalogProvider>()
         .register::<CanonicalModelPricing>()
         .register::<CatalogCapability>()
+        .register::<CanonicalModelThinking>()
+        .register::<CatalogLimits>()
+        .register::<CatalogMetadata>()
         .register::<Pick>();
     Typescript::default()
         .export_to(

--- a/tests/zod-typecheck/serde-aliases.test.ts
+++ b/tests/zod-typecheck/serde-aliases.test.ts
@@ -41,6 +41,11 @@ const mappedEntries = raw.entries.map(entry => ({
   inputCost: entry.modelPricing?.inputCost ?? entry.modelPricing?.input_cost,
   provider: entry.providerInfo?.displayName ?? entry.providerInfo?.display_name,
   tools: entry.modelCapability?.supportsTools ?? entry.modelCapability?.supports_tools,
+  thinking: entry.modelThinking && "configured" in entry.modelThinking
+    ? entry.modelThinking.configured?.effortLevels ?? entry.modelThinking.configured?.effort_levels
+    : entry.modelThinking?.extensible.effort_levels,
+  limits: entry.modelLimits?.maxInputTokens ?? entry.modelLimits?.max_input_tokens,
+  label: entry.modelMetadata?.displayLabel ?? entry.modelMetadata?.display_label,
 }));
 
 function consumeEntry(entry: Pick<CatalogEntry, "modelId" | "modelPricing">) {
@@ -48,6 +53,8 @@ function consumeEntry(entry: Pick<CatalogEntry, "modelId" | "modelPricing">) {
 }
 
 const structurallyAssigned: { modelId?: string | null } = raw.entries[0];
+type EntryPresentation = Pick<CatalogEntry, "modelId" | "modelPricing" | "modelThinking" | "modelLimits" | "modelMetadata">;
+const presentation: EntryPresentation = raw.entries[0];
 
 type QueryResult<T> = { data: T };
 function consumeQuery<T extends { entries: CatalogEntry[] }>(query: QueryResult<T>) {
@@ -60,4 +67,5 @@ const queriedEntries = consumeQuery(queryResult);
 void duplicateOptional;
 void mappedEntries;
 void structurallyAssigned;
+void presentation;
 void queriedEntries;


### PR DESCRIPTION
## What changed

- recursively mark fully optional serde alias unions for symbolic TypeScript lowering after enum and flatten rewrites finish
- preserve required alias XORs and partially relaxed flatten-collision semantics
- add a Rust-to-generated-TypeScript regression covering nested enum variants, flattened alias parts, additional properties, catalog entries, mapping, property reads, structural assignment, `Pick`, and a generic query wrapper

## Why

PR #556 simplified ordinary optional alias structs, but nested alias unions moved into synthesized enum and flatten intersections after the local lowering pass. TypeScript then distributed those intersections into an exponential union and reported TS2590.

The final traversal catches those moved unions. It only marks optional unions that are still fully exclusive or have had all exclusions removed, avoiding partially relaxed collision shapes.

## Validation

- confirmed the fixture fails on `4c23158ad8b42e28c9663b5cfa6c9a93a7fe0b82` with TS2590
- `cargo fmt --all -- --check`
- `cargo test -p specta-serde -p specta-typescript`
- `cargo test -p specta-tests --test test typescript` (40 passed)
- generated bindings plus `npx tsc -p tests/zod-typecheck/tsconfig.json`
- `cargo clippy -p specta-serde -p specta-typescript --lib` (passes with one pre-existing `unnecessary_fold` warning in untouched code)
- three-pass Codex review/fix loop, final pass clean
