### PR TITLE
feat(openapi): close the real-world document gaps

### DIFF
--- a/specta-jsonschema/src/jsonschema.rs
+++ b/specta-jsonschema/src/jsonschema.rs
@@ -15,6 +15,7 @@ pub struct JsonSchema {
     description: Option<Cow<'static, str>>,
     comment: Option<Cow<'static, str>>,
     allow_additional_properties: bool,
+    number_formats: bool,
 }
 
 impl JsonSchema {
@@ -64,6 +65,18 @@ impl JsonSchema {
         self
     }
 
+    /// Annotate numeric schemas with OpenAPI-style `format` values: `int32`
+    /// for integers that fit a signed 32-bit value, `int64` for wider ones,
+    /// and `float`/`double` for `f32`/`f64`.
+    ///
+    /// Off by default: `format` is an annotation keyword in JSON Schema, and
+    /// the numeric bounds already state the exact range. Generators that map
+    /// formats to language types (OpenAPI tooling in particular) can opt in.
+    pub fn number_formats(mut self, enabled: bool) -> Self {
+        self.number_formats = enabled;
+        self
+    }
+
     /// Export the schema document as a pretty-printed JSON string.
     pub fn export(&self, types: &Types, format: impl Format) -> Result<String, Error> {
         Ok(serde_json::to_string_pretty(
@@ -88,7 +101,12 @@ impl JsonSchema {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let renderer = Renderer::new(self.schema_version, types, self.allow_additional_properties);
+        let renderer = Renderer::new(
+            self.schema_version,
+            types,
+            self.allow_additional_properties,
+            self.number_formats,
+        );
         let (definitions, _) = renderer.render_definitions(&roots)?;
 
         let mut root = Map::new();
@@ -144,6 +162,7 @@ impl JsonSchema {
             self.schema_version,
             mapped,
             self.allow_additional_properties,
+            self.number_formats,
         );
         let (definitions, mut roots) = renderer.render_definitions(&roots)?;
         let root_schema = roots.pop().unwrap_or(Value::Bool(true));

--- a/specta-jsonschema/src/render.rs
+++ b/specta-jsonschema/src/render.rs
@@ -47,6 +47,7 @@ pub(crate) struct Renderer<'a> {
     in_progress_types: Vec<DefinitionSource>,
     name_counts: BTreeMap<Cow<'static, str>, usize>,
     allow_additional_properties: bool,
+    number_formats: bool,
 }
 
 impl<'a> Renderer<'a> {
@@ -54,6 +55,7 @@ impl<'a> Renderer<'a> {
         schema_version: SchemaVersion,
         types: &'a Types,
         allow_additional_properties: bool,
+        number_formats: bool,
     ) -> Self {
         let mut name_counts = BTreeMap::new();
         for ndt in types.into_sorted_iter() {
@@ -69,6 +71,7 @@ impl<'a> Renderer<'a> {
             in_progress_types: Vec::new(),
             name_counts,
             allow_additional_properties,
+            number_formats,
         }
     }
 
@@ -183,7 +186,7 @@ impl<'a> Renderer<'a> {
         }
 
         match dt {
-            DataType::Primitive(primitive) => Ok(primitive_schema(primitive)),
+            DataType::Primitive(primitive) => Ok(self.primitive_schema(primitive)),
             DataType::List(list) => self.render_list(list, generics, path, depth),
             DataType::Map(map) => self.render_map(map, generics, path, depth),
             DataType::Struct(strct) => self.render_struct(strct, generics, path, depth),
@@ -507,7 +510,7 @@ impl<'a> Renderer<'a> {
         depth: usize,
     ) -> Result<Option<Value>, Error> {
         Ok(match dt {
-            DataType::Primitive(Primitive::char) => Some(primitive_schema(&Primitive::char)),
+            DataType::Primitive(Primitive::char) => Some(self.primitive_schema(&Primitive::char)),
             DataType::Primitive(Primitive::str) => None,
             DataType::Primitive(Primitive::bool) => Some(object([(
                 "enum",
@@ -1230,6 +1233,40 @@ fn default_generics(ndt: &NamedDataType) -> Generics {
         }
     }
     generics
+}
+
+impl Renderer<'_> {
+    /// A primitive's schema, with an OpenAPI-style `format` annotation when
+    /// [`number formats`](crate::JsonSchema::number_formats) are enabled.
+    fn primitive_schema(&self, primitive: &Primitive) -> Value {
+        let mut schema = primitive_schema(primitive);
+        if self.number_formats
+            && let Some(format) = number_format(primitive)
+            && let Value::Object(object) = &mut schema
+        {
+            object.insert("format".to_string(), string(format));
+        }
+        schema
+    }
+}
+
+/// The OpenAPI `format` for a numeric primitive: `int32` when every value
+/// fits a signed 32-bit integer, `int64` for wider integers (`u64` included,
+/// by the OpenAPI convention; the bounds state the exact range), and
+/// `float`/`double` for the IEEE 754 sizes. Widths OpenAPI has no name for
+/// get none.
+fn number_format(primitive: &Primitive) -> Option<&'static str> {
+    match primitive {
+        Primitive::i8 | Primitive::i16 | Primitive::i32 | Primitive::u8 | Primitive::u16 => {
+            Some("int32")
+        }
+        Primitive::i64 | Primitive::isize | Primitive::u32 | Primitive::u64 | Primitive::usize => {
+            Some("int64")
+        }
+        Primitive::f32 => Some("float"),
+        Primitive::f64 => Some("double"),
+        _ => None,
+    }
 }
 
 fn primitive_schema(primitive: &Primitive) -> Value {

--- a/specta-openapi/src/lib.rs
+++ b/specta-openapi/src/lib.rs
@@ -59,5 +59,5 @@ mod transform;
 
 pub use error::Error;
 pub use openapi::{OpenApi, OutputFormat, SchemaMode};
-pub use openapiv3::{Components, OpenAPI, ReferenceOr, Schema};
-pub use operation::{Method, Operation};
+pub use openapiv3::{Components, OpenAPI, ReferenceOr, Schema, SecurityScheme};
+pub use operation::{Method, Operation, Param};

--- a/specta-openapi/src/openapi.rs
+++ b/specta-openapi/src/openapi.rs
@@ -1,6 +1,9 @@
 use std::{borrow::Cow, path::Path};
 
-use openapiv3::{Components, Info, OpenAPI, Paths};
+use indexmap::IndexMap;
+use openapiv3::{
+    Components, Contact, Info, OpenAPI, Paths, ReferenceOr, SecurityScheme, Server, Tag,
+};
 use specta::{Format, Types};
 
 use crate::{Error, operation::Operation, resolve::resolve, transform::components};
@@ -36,6 +39,10 @@ pub struct OpenApi {
     output_format: OutputFormat,
     schema_mode: SchemaMode,
     operations: Vec<Operation>,
+    servers: Vec<Server>,
+    tags: Vec<Tag>,
+    contact: Option<Contact>,
+    security_schemes: IndexMap<String, SecurityScheme>,
 }
 
 impl Default for OpenApi {
@@ -47,6 +54,10 @@ impl Default for OpenApi {
             output_format: OutputFormat::Json,
             schema_mode: SchemaMode::Strict,
             operations: Vec::new(),
+            servers: Vec::new(),
+            tags: Vec::new(),
+            contact: None,
+            security_schemes: IndexMap::new(),
         }
     }
 }
@@ -73,6 +84,76 @@ impl OpenApi {
     pub fn description(mut self, description: impl Into<Cow<'static, str>>) -> Self {
         self.description = Some(description.into());
         self
+    }
+
+    /// Add a server the API is reachable on, in the document's `servers` list.
+    pub fn server(mut self, url: impl Into<String>) -> Self {
+        self.servers.push(Server {
+            url: url.into(),
+            ..Default::default()
+        });
+        self
+    }
+
+    /// Add a server with a human-readable description.
+    pub fn server_described(
+        mut self,
+        url: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self {
+        self.servers.push(Server {
+            url: url.into(),
+            description: Some(description.into()),
+            ..Default::default()
+        });
+        self
+    }
+
+    /// Configure the API contact in the generated document's `info` object.
+    pub fn contact(mut self, name: impl Into<String>, url: impl Into<String>) -> Self {
+        self.contact = Some(Contact {
+            name: Some(name.into()),
+            url: Some(url.into()),
+            ..Default::default()
+        });
+        self
+    }
+
+    /// Add a tag with a description, which generators and documentation use
+    /// to group operations declared with [`Operation::tag`].
+    pub fn tag(mut self, name: impl Into<String>, description: impl Into<String>) -> Self {
+        self.tags.push(Tag {
+            name: name.into(),
+            description: Some(description.into()),
+            ..Default::default()
+        });
+        self
+    }
+
+    /// Register a security scheme under `name`, which operations reference
+    /// with [`Operation::security`]. The full [`SecurityScheme`] surface is
+    /// [`openapiv3`]'s; [`bearer_security_scheme`](Self::bearer_security_scheme)
+    /// covers the common token case.
+    pub fn security_scheme(mut self, name: impl Into<String>, scheme: SecurityScheme) -> Self {
+        self.security_schemes.insert(name.into(), scheme);
+        self
+    }
+
+    /// Register an HTTP bearer-token security scheme under `name`.
+    pub fn bearer_security_scheme(
+        self,
+        name: impl Into<String>,
+        bearer_format: impl Into<String>,
+    ) -> Self {
+        self.security_scheme(
+            name,
+            SecurityScheme::HTTP {
+                scheme: "bearer".to_string(),
+                bearer_format: Some(bearer_format.into()),
+                description: None,
+                extensions: IndexMap::new(),
+            },
+        )
     }
 
     /// Configure JSON or YAML serialization.
@@ -133,14 +214,24 @@ impl OpenApi {
             crate::paths::paths(&self.operations, &resolved)?
         };
 
+        let mut components = components;
+        for (name, scheme) in &self.security_schemes {
+            components
+                .security_schemes
+                .insert(name.clone(), ReferenceOr::Item(scheme.clone()));
+        }
+
         Ok(OpenAPI {
             openapi: "3.0.3".to_string(),
             info: Info {
                 title: self.title.to_string(),
                 description: self.description.as_ref().map(ToString::to_string),
                 version: self.version.to_string(),
+                contact: self.contact.clone(),
                 ..Default::default()
             },
+            servers: self.servers.clone(),
+            tags: self.tags.clone(),
             paths,
             components: Some(components),
             ..Default::default()

--- a/specta-openapi/src/operation.rs
+++ b/specta-openapi/src/operation.rs
@@ -39,7 +39,83 @@ pub(crate) struct Parameter {
     pub(crate) location: ParameterLocation,
     pub(crate) required: bool,
     pub(crate) description: Option<Cow<'static, str>>,
+    pub(crate) example: Option<serde_json::Value>,
     pub(crate) ty: Body,
+}
+
+/// A parameter under construction: [`Param::path`], [`Param::query`], or
+/// [`Param::header`] pick the location and type, and the builder methods add
+/// what the bare [`Operation`] conveniences cannot say.
+///
+/// ```rust
+/// # use specta_openapi::{Operation, Param};
+/// # use serde_json::json;
+/// let operation = Operation::get("/v1/weather/forecast")
+///     .parameter(
+///         Param::query::<f64>("lat")
+///             .required()
+///             .description("Latitude, WGS84 degrees, -90 to 90")
+///             .example(json!(35.0)),
+///     );
+/// ```
+#[derive(Debug, Clone)]
+pub struct Param(pub(crate) Parameter);
+
+impl Param {
+    /// A templated path parameter of type `T`. Path parameters are always
+    /// required.
+    pub fn path<T: Type>(name: impl Into<Cow<'static, str>>) -> Self {
+        Self(Parameter {
+            name: name.into(),
+            location: ParameterLocation::Path,
+            required: true,
+            description: None,
+            example: None,
+            ty: capture::<T>(),
+        })
+    }
+
+    /// A query parameter of type `T`, optional unless [`required`](Self::required).
+    pub fn query<T: Type>(name: impl Into<Cow<'static, str>>) -> Self {
+        Self(Parameter {
+            name: name.into(),
+            location: ParameterLocation::Query,
+            required: false,
+            description: None,
+            example: None,
+            ty: capture::<T>(),
+        })
+    }
+
+    /// A header parameter of type `T`, optional unless [`required`](Self::required).
+    pub fn header<T: Type>(name: impl Into<Cow<'static, str>>) -> Self {
+        Self(Parameter {
+            name: name.into(),
+            location: ParameterLocation::Header,
+            required: false,
+            description: None,
+            example: None,
+            ty: capture::<T>(),
+        })
+    }
+
+    /// Marks the parameter required.
+    pub fn required(mut self) -> Self {
+        self.0.required = true;
+        self
+    }
+
+    /// Sets the parameter's description.
+    pub fn description(mut self, description: impl Into<Cow<'static, str>>) -> Self {
+        self.0.description = Some(description.into());
+        self
+    }
+
+    /// Sets the parameter's example value.
+    pub fn example(mut self, example: serde_json::Value) -> Self {
+        self.0.example = Some(example);
+        self
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -54,8 +130,14 @@ pub(crate) struct Body {
 pub(crate) struct Response {
     pub(crate) status: u16,
     pub(crate) description: Cow<'static, str>,
+    pub(crate) content_type: Option<Cow<'static, str>>,
     pub(crate) body: Option<Body>,
 }
+
+/// One way a caller may satisfy an operation's security: scheme names (as
+/// registered on the document) to their required scopes. An empty requirement
+/// means the operation also works anonymously.
+pub(crate) type SecurityRequirement = Vec<(Cow<'static, str>, Vec<String>)>;
 
 /// A single endpoint: one method on one path.
 ///
@@ -85,6 +167,7 @@ pub struct Operation {
     pub(crate) parameters: Vec<Parameter>,
     pub(crate) request_body: Option<Body>,
     pub(crate) responses: Vec<Response>,
+    pub(crate) security: Vec<SecurityRequirement>,
 }
 
 impl Operation {
@@ -103,6 +186,7 @@ impl Operation {
             parameters: Vec::new(),
             request_body: None,
             responses: Vec::new(),
+            security: Vec::new(),
         }
     }
 
@@ -159,38 +243,25 @@ impl Operation {
     ///
     /// `T` is what the extractor parses the segment into, so `/users/{id}` served by a
     /// `Path<u32>` is `path_param::<u32>("id")` and exports as an integer.
-    pub fn path_param<T: Type>(mut self, name: impl Into<Cow<'static, str>>) -> Self {
-        self.parameters.push(Parameter {
-            name: name.into(),
-            location: ParameterLocation::Path,
-            required: true,
-            description: None,
-            ty: capture::<T>(),
-        });
-        self
+    pub fn path_param<T: Type>(self, name: impl Into<Cow<'static, str>>) -> Self {
+        self.parameter(Param::path::<T>(name))
     }
 
     /// Declares an optional query parameter of type `T`.
-    pub fn query_param<T: Type>(mut self, name: impl Into<Cow<'static, str>>) -> Self {
-        self.parameters.push(Parameter {
-            name: name.into(),
-            location: ParameterLocation::Query,
-            required: false,
-            description: None,
-            ty: capture::<T>(),
-        });
-        self
+    pub fn query_param<T: Type>(self, name: impl Into<Cow<'static, str>>) -> Self {
+        self.parameter(Param::query::<T>(name))
     }
 
     /// Declares an optional header parameter of type `T`.
-    pub fn header_param<T: Type>(mut self, name: impl Into<Cow<'static, str>>) -> Self {
-        self.parameters.push(Parameter {
-            name: name.into(),
-            location: ParameterLocation::Header,
-            required: false,
-            description: None,
-            ty: capture::<T>(),
-        });
+    pub fn header_param<T: Type>(self, name: impl Into<Cow<'static, str>>) -> Self {
+        self.parameter(Param::header::<T>(name))
+    }
+
+    /// Declares a parameter built with [`Param`], which can say what the bare
+    /// conveniences cannot: required query parameters, descriptions, and
+    /// example values.
+    pub fn parameter(mut self, param: Param) -> Self {
+        self.parameters.push(param.0);
         self
     }
 
@@ -212,8 +283,51 @@ impl Operation {
         self.responses.push(Response {
             status,
             description: description.into(),
+            content_type: None,
             body: Some(capture::<T>()),
         });
+        self
+    }
+
+    /// Declares a response body of `T` for `status` served with a content
+    /// type other than `application/json`, such as RFC 9457's
+    /// `application/problem+json`.
+    pub fn response_as<T: Type>(
+        mut self,
+        status: u16,
+        description: impl Into<Cow<'static, str>>,
+        content_type: impl Into<Cow<'static, str>>,
+    ) -> Self {
+        self.responses.push(Response {
+            status,
+            description: description.into(),
+            content_type: Some(content_type.into()),
+            body: Some(capture::<T>()),
+        });
+        self
+    }
+
+    /// Adds one way a caller may satisfy this operation's security: scheme
+    /// names (as registered on the document) to their required scopes. Each
+    /// call adds an alternative; a caller needs to satisfy only one.
+    pub fn security<N: Into<Cow<'static, str>>>(
+        mut self,
+        requirement: impl IntoIterator<Item = (N, Vec<String>)>,
+    ) -> Self {
+        self.security.push(
+            requirement
+                .into_iter()
+                .map(|(name, scopes)| (name.into(), scopes))
+                .collect(),
+        );
+        self
+    }
+
+    /// Also allows the operation to be called with no credentials at all: the
+    /// empty security requirement, which makes any [`security`](Self::security)
+    /// alternatives optional.
+    pub fn security_optional(mut self) -> Self {
+        self.security.push(Vec::new());
         self
     }
 
@@ -239,6 +353,7 @@ impl Operation {
         self.responses.push(Response {
             status,
             description: description.into(),
+            content_type: None,
             body: None,
         });
         self

--- a/specta-openapi/src/paths.rs
+++ b/specta-openapi/src/paths.rs
@@ -9,7 +9,7 @@ use indexmap::IndexMap;
 use openapiv3::{
     MediaType, Operation as OpenApiOperation, Parameter as OpenApiParameter, ParameterData,
     ParameterSchemaOrContent, PathItem, Paths, ReferenceOr, RequestBody, Response, Responses,
-    StatusCode,
+    SecurityRequirement, StatusCode,
 };
 
 const JSON: &str = "application/json";
@@ -60,11 +60,12 @@ fn lower(operation: &Operation, resolved: &Resolved) -> Result<OpenApiOperation,
 
     let mut responses = Responses::default();
     for response in &operation.responses {
+        let content_type = response.content_type.as_deref().unwrap_or(JSON);
         responses.responses.insert(
             StatusCode::Code(response.status),
             ReferenceOr::Item(Response {
                 description: response.description.to_string(),
-                content: content_of(response.body.as_ref(), resolved)?,
+                content: content_of(response.body.as_ref(), content_type, resolved)?,
                 ..Default::default()
             }),
         );
@@ -72,7 +73,7 @@ fn lower(operation: &Operation, resolved: &Resolved) -> Result<OpenApiOperation,
 
     let request_body = match &operation.request_body {
         Some(body) => Some(ReferenceOr::Item(RequestBody {
-            content: content_of(Some(body), resolved)?,
+            content: content_of(Some(body), JSON, resolved)?,
             required: true,
             ..Default::default()
         })),
@@ -91,12 +92,25 @@ fn lower(operation: &Operation, resolved: &Resolved) -> Result<OpenApiOperation,
             .collect::<Result<Vec<_>, _>>()?,
         request_body,
         responses,
+        security: (!operation.security.is_empty()).then(|| {
+            operation
+                .security
+                .iter()
+                .map(|requirement| {
+                    requirement
+                        .iter()
+                        .map(|(name, scopes)| (name.to_string(), scopes.clone()))
+                        .collect::<SecurityRequirement>()
+                })
+                .collect()
+        }),
         ..Default::default()
     })
 }
 
 fn content_of(
     body: Option<&Body>,
+    content_type: &str,
     resolved: &Resolved,
 ) -> Result<IndexMap<String, MediaType>, Error> {
     let Some(body) = body else {
@@ -106,7 +120,7 @@ fn content_of(
         .get(&body.dt)
         .ok_or(Error::UnresolvedOperationTypes)?;
     Ok(IndexMap::from_iter([(
-        JSON.to_string(),
+        content_type.to_string(),
         MediaType {
             schema: Some(schema.clone()),
             ..Default::default()
@@ -128,7 +142,7 @@ fn parameter(
         required: parameter.required,
         deprecated: None,
         format: ParameterSchemaOrContent::Schema(schema.clone()),
-        example: None,
+        example: parameter.example.clone(),
         examples: IndexMap::new(),
         explode: None,
         extensions: IndexMap::new(),

--- a/specta-openapi/src/transform.rs
+++ b/specta-openapi/src/transform.rs
@@ -11,7 +11,10 @@ pub(crate) fn components(
     format: impl Format,
     mode: SchemaMode,
 ) -> Result<Components, Error> {
-    let mut schema = specta_jsonschema::JsonSchema::default().export_value(types, format)?;
+    let mut schema = specta_jsonschema::JsonSchema::default()
+        // OpenAPI generators map numeric formats to language types.
+        .number_formats(true)
+        .export_value(types, format)?;
     let definitions = schema
         .as_object_mut()
         .and_then(|root| root.remove("$defs").or_else(|| root.remove("definitions")))
@@ -169,6 +172,8 @@ fn transform_object(
     if let Some(constant) = schema.remove("const") {
         schema.insert("enum".to_string(), Value::Array(vec![constant]));
     }
+
+    compact_string_enum(&mut schema);
 
     if schema.get("type").and_then(Value::as_str) == Some("null") {
         if mode == SchemaMode::Strict {
@@ -380,4 +385,55 @@ fn is_nullable_only(value: &Value) -> bool {
                     )
                 }))
     })
+}
+
+/// Collapses a `oneOf` whose members are all single-value string enums - the
+/// shape a plain string enum renders as - into the compact
+/// `{ "type": "string", "enum": [...] }` form generators handle best.
+/// Per-variant descriptions have no home in the compact form, so when any
+/// member carries one they are retained in `x-specta-enum-descriptions`,
+/// keyed by value.
+fn compact_string_enum(schema: &mut Map<String, Value>) {
+    let Some(Value::Array(members)) = schema.get("oneOf") else {
+        return;
+    };
+    let mut values = Vec::with_capacity(members.len());
+    let mut descriptions = Map::new();
+    for member in members {
+        let Value::Object(member) = member else {
+            return;
+        };
+        // Exactly a single string value - members are inspected before their
+        // own transform runs, so both the JSON Schema `const` form and the
+        // already-lowered single-value `enum` form appear here - with nothing
+        // but an optional description beside it.
+        let value = match (member.get("const"), member.get("enum")) {
+            (Some(Value::String(value)), None) => value,
+            (None, Some(Value::Array(constants))) => match constants.as_slice() {
+                [Value::String(value)] => value,
+                _ => return,
+            },
+            _ => return,
+        };
+        if member
+            .keys()
+            .any(|key| !matches!(key.as_str(), "const" | "enum" | "description"))
+        {
+            return;
+        }
+        if let Some(Value::String(description)) = member.get("description") {
+            // Doc comments arrive with their leading space.
+            descriptions.insert(value.clone(), Value::String(description.trim().to_string()));
+        }
+        values.push(Value::String(value.clone()));
+    }
+    schema.remove("oneOf");
+    schema.insert("type".to_string(), Value::String("string".into()));
+    schema.insert("enum".to_string(), Value::Array(values));
+    if !descriptions.is_empty() {
+        schema.insert(
+            "x-specta-enum-descriptions".to_string(),
+            Value::Object(descriptions),
+        );
+    }
 }

--- a/tests/tests/openapi.rs
+++ b/tests/tests/openapi.rs
@@ -849,3 +849,150 @@ fn openapi_types_parameters_from_their_extracted_type() {
     assert_eq!(parameters[1]["in"], "query");
     assert_eq!(parameters[1]["schema"]["type"], "string");
 }
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(rename_all = "snake_case")]
+enum PlainStringEnum {
+    /// Automatic per-location blend.
+    Auto,
+    Gfs,
+    Ecmwf,
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+struct NumericFormats {
+    small: u16,
+    lead: u32,
+    wide: i64,
+    ratio: f32,
+    value: f64,
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+struct ProblemBody {
+    title: String,
+}
+
+/// Numeric schemas carry OpenAPI formats, and plain string enums render in
+/// the compact `type: string, enum: [...]` form with variant docs retained in
+/// an extension.
+#[test]
+fn numeric_formats_and_compact_string_enums() {
+    let types = Types::default()
+        .register::<NumericFormats>()
+        .register::<PlainStringEnum>();
+    let document = OpenApi::default()
+        .export_document(&types, specta_serde::Format)
+        .unwrap();
+    let json = serde_json::to_value(&document).unwrap();
+    let schemas = &json["components"]["schemas"];
+
+    let numeric = &schemas["NumericFormats"]["properties"];
+    assert_eq!(numeric["small"]["format"], "int32");
+    assert_eq!(numeric["lead"]["format"], "int64");
+    assert_eq!(numeric["wide"]["format"], "int64");
+    assert_eq!(numeric["ratio"]["format"], "float");
+    assert_eq!(numeric["value"]["format"], "double");
+
+    let string_enum = &schemas["PlainStringEnum"];
+    assert_eq!(string_enum["type"], "string");
+    assert_eq!(
+        string_enum["enum"],
+        serde_json::json!(["auto", "gfs", "ecmwf"])
+    );
+    assert!(string_enum.get("oneOf").is_none());
+    assert_eq!(
+        string_enum["x-specta-enum-descriptions"]["auto"],
+        "Automatic per-location blend."
+    );
+}
+
+/// The `Param` builder covers what the bare conveniences cannot: required
+/// query parameters, descriptions, and example values.
+#[test]
+fn parameters_carry_required_description_and_example() {
+    use specta_openapi::Param;
+
+    let types = Types::default().register::<ProblemBody>();
+    let document = OpenApi::default()
+        .operation(
+            Operation::get("/v1/weather/forecast")
+                .parameter(
+                    Param::query::<f64>("lat")
+                        .required()
+                        .description("Latitude, WGS84 degrees, -90 to 90")
+                        .example(serde_json::json!(35.0)),
+                )
+                .query_param::<u32>("horizon_hours")
+                .response::<ProblemBody>(200, "ok"),
+        )
+        .export_document(&types, specta_serde::Format)
+        .unwrap();
+    let json = serde_json::to_value(&document).unwrap();
+    let parameters = &json["paths"]["/v1/weather/forecast"]["get"]["parameters"];
+
+    assert_eq!(parameters[0]["name"], "lat");
+    assert_eq!(parameters[0]["required"], true);
+    assert_eq!(
+        parameters[0]["description"],
+        "Latitude, WGS84 degrees, -90 to 90"
+    );
+    assert_eq!(parameters[0]["example"], 35.0);
+    assert_eq!(parameters[0]["schema"]["format"], "double");
+
+    // The bare convenience stays optional (openapiv3 omits `required: false`)
+    // with no annotations.
+    assert_eq!(parameters[1]["name"], "horizon_hours");
+    assert_ne!(parameters[1]["required"], serde_json::json!(true));
+    assert!(parameters[1].get("example").is_none());
+}
+
+/// Error responses can be served as `application/problem+json`, security
+/// schemes register on the document, and operations state their security
+/// alternatives, the anonymous option included.
+#[test]
+fn content_types_security_and_document_metadata() {
+    let types = Types::default().register::<ProblemBody>();
+    let document = OpenApi::default()
+        .title("Orrery API")
+        .version("1.0.0")
+        .server_described("https://api.orr.sh", "Production")
+        .contact("Orrery", "https://orreryhq.com")
+        .tag("weather", "Weather intelligence")
+        .bearer_security_scheme("api_key", "opaque")
+        .operation(
+            Operation::get("/v1/me")
+                .tag("weather")
+                .response::<ProblemBody>(200, "ok")
+                .response_as::<ProblemBody>(
+                    401,
+                    "Missing or unknown key",
+                    "application/problem+json",
+                )
+                .security([("api_key", Vec::new())])
+                .security_optional(),
+        )
+        .export_document(&types, specta_serde::Format)
+        .unwrap();
+    let json = serde_json::to_value(&document).unwrap();
+
+    assert_eq!(json["servers"][0]["url"], "https://api.orr.sh");
+    assert_eq!(json["servers"][0]["description"], "Production");
+    assert_eq!(json["info"]["contact"]["name"], "Orrery");
+    assert_eq!(json["tags"][0]["description"], "Weather intelligence");
+    assert_eq!(
+        json["components"]["securitySchemes"]["api_key"]["scheme"],
+        "bearer"
+    );
+
+    let operation = &json["paths"]["/v1/me"]["get"];
+    assert!(operation["responses"]["200"]["content"]["application/json"].is_object());
+    assert!(operation["responses"]["401"]["content"]["application/problem+json"].is_object());
+    assert_eq!(
+        operation["security"],
+        serde_json::json!([{ "api_key": [] }, {}])
+    );
+}

--- a/tests/tests/snapshots/test__openapi__openapi-representative-shapes.snap
+++ b/tests/tests/snapshots/test__openapi__openapi-representative-shapes.snap
@@ -28,6 +28,7 @@ expression: "serde_json::to_string_pretty(&value).expect(\"snapshot value should
                 "additionalProperties": false,
                 "properties": {
                   "percent": {
+                    "format": "float",
                     "type": "number"
                   }
                 },
@@ -74,6 +75,7 @@ expression: "serde_json::to_string_pretty(&value).expect(\"snapshot value should
         "properties": {
           "fixed": {
             "items": {
+              "format": "int32",
               "maximum": 255,
               "minimum": 0,
               "type": "integer"
@@ -84,12 +86,14 @@ expression: "serde_json::to_string_pretty(&value).expect(\"snapshot value should
           },
           "id": {
             "description": " Stable identifier.",
+            "format": "int64",
             "minimum": 0,
             "type": "integer",
             "x-specta-maximum": 18446744073709551615
           },
           "labels": {
             "additionalProperties": {
+              "format": "int32",
               "maximum": 2147483647,
               "minimum": -2147483648,
               "type": "integer"
@@ -144,6 +148,7 @@ expression: "serde_json::to_string_pretty(&value).expect(\"snapshot value should
         "properties": {
           "fixed": {
             "items": {
+              "format": "int32",
               "maximum": 255,
               "minimum": 0,
               "type": "integer"
@@ -154,12 +159,14 @@ expression: "serde_json::to_string_pretty(&value).expect(\"snapshot value should
           },
           "id": {
             "description": " Stable identifier.",
+            "format": "int64",
             "minimum": 0,
             "type": "integer",
             "x-specta-maximum": 18446744073709551615
           },
           "labels": {
             "additionalProperties": {
+              "format": "int32",
               "maximum": 2147483647,
               "minimum": -2147483648,
               "type": "integer"
@@ -195,6 +202,7 @@ expression: "serde_json::to_string_pretty(&value).expect(\"snapshot value should
             ]
           },
           "value": {
+            "format": "int64",
             "maximum": 4294967295,
             "minimum": 0,
             "type": "integer"
@@ -222,11 +230,13 @@ expression: "serde_json::to_string_pretty(&value).expect(\"snapshot value should
       "OverlappingUntagged": {
         "anyOf": [
           {
+            "format": "int64",
             "maximum": 4294967295,
             "minimum": 0,
             "type": "integer"
           },
           {
+            "format": "int64",
             "maximum": 4294967295,
             "minimum": 0,
             "type": "integer"


### PR DESCRIPTION
Dogfooding the exporter against a production HTTP API ([orrery.sh](https://orrery.sh), 14 endpoints) surfaced the things a real document needs to state that the exporter couldn't. This closes them:

- numeric formats: an opt-in `number_formats` knob on specta-jsonschema (int32/int64/float/double by width, off by default so plain JSON Schema output is unchanged); specta-openapi turns it on, since OpenAPI generators map formats to language types
- plain string enums compact from oneOf-of-consts to the `{ "type": "string", "enum": [...] }` form generators handle best, with per-variant doc comments retained in `x-specta-enum-descriptions`
- a `Param` builder for what the bare conveniences cannot say: required query parameters, descriptions, example values, and header parameters
- `response_as` declares a response served as something other than `application/json`, e.g. RFC 9457's `application/problem+json` or `text/html`
- the document builder gains `servers`, `contact`, `tags`, and security schemes (a bearer convenience included); operations state their security requirement alternatives, the anonymous-allowed empty option included

Existing behavior is otherwise unchanged: the representative-shapes snapshot moved only by the added format annotations.
