### PR TITLE
feat(openapi): target OpenAPI 3.1 by default behind an OasVersion knob

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2154,6 +2154,7 @@ dependencies = [
 name = "specta-openapi"
 version = "0.0.4"
 dependencies = [
+ "serde",
  "serde_json",
  "serde_yaml",
  "specta",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1497,17 +1497,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "openapiv3"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8d427828b22ae1fff2833a03d8486c2c881367f1c336349f307f321e7f4d05"
-dependencies = [
- "indexmap 2.14.0",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "ordered-float"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2165,8 +2154,6 @@ dependencies = [
 name = "specta-openapi"
 version = "0.0.4"
 dependencies = [
- "indexmap 2.14.0",
- "openapiv3",
  "serde_json",
  "serde_yaml",
  "specta",
@@ -2241,7 +2228,6 @@ dependencies = [
  "glam 0.33.2",
  "heapless",
  "insta",
- "openapiv3",
  "ordered-float",
  "semver",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,6 +1006,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heapless"
@@ -1262,11 +1267,38 @@ dependencies = [
  "getrandom 0.3.4",
  "idna",
  "itoa",
- "jsonschema-regex",
+ "jsonschema-regex 0.46.10",
  "num-cmp",
  "num-traits",
  "percent-encoding",
- "referencing",
+ "referencing 0.46.10",
+ "regex",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9baf521a926fd1e6f94af6922be9686b61c8a89a5fb7e14d6a1e21b79738d4cc"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "jsonschema-regex 0.48.1",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing 0.48.1",
  "regex",
  "serde",
  "serde_json",
@@ -1279,6 +1311,15 @@ name = "jsonschema-regex"
 version = "0.46.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbd1086b01b9349fd4ef9a07433965af64c8ce8159abe633a189e4ff817bd13"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d668f4775619127513d9a4f190704d20a66d20ccf0efc258f8ed42548e5fd7cd"
 dependencies = [
  "regex-syntax",
 ]
@@ -1753,6 +1794,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df843f41f0cb459649f64a8b6b10579cf454f7a7420dc702767c81a26f23d780"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.17.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,7 +2181,7 @@ name = "specta-jsonschema"
 version = "0.0.4"
 dependencies = [
  "insta",
- "jsonschema",
+ "jsonschema 0.46.10",
  "serde",
  "serde_json",
  "specta",
@@ -2229,6 +2287,7 @@ dependencies = [
  "glam 0.33.2",
  "heapless",
  "insta",
+ "jsonschema 0.48.1",
  "ordered-float",
  "semver",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2287,6 +2287,7 @@ dependencies = [
  "glam 0.33.2",
  "heapless",
  "insta",
+ "jiff",
  "jsonschema 0.48.1",
  "ordered-float",
  "semver",
@@ -2315,6 +2316,8 @@ dependencies = [
  "trybuild",
  "uhlc",
  "ulid",
+ "url",
+ "uuid",
  "wasm-bindgen",
 ]
 

--- a/specta-jsonschema/src/jsonschema.rs
+++ b/specta-jsonschema/src/jsonschema.rs
@@ -15,6 +15,7 @@ pub struct JsonSchema {
     description: Option<Cow<'static, str>>,
     comment: Option<Cow<'static, str>>,
     allow_additional_properties: bool,
+    number_formats: bool,
 }
 
 impl JsonSchema {
@@ -64,6 +65,18 @@ impl JsonSchema {
         self
     }
 
+    /// Annotate numeric schemas with OpenAPI-style `format` values: `int32`
+    /// for integers that fit a signed 32-bit value, `int64` for wider ones,
+    /// and `float`/`double` for `f32`/`f64`.
+    ///
+    /// Off by default: `format` is an annotation keyword in JSON Schema, and
+    /// the numeric bounds already state the exact range. Generators that map
+    /// formats to language types (OpenAPI tooling in particular) can opt in.
+    pub fn number_formats(mut self, enabled: bool) -> Self {
+        self.number_formats = enabled;
+        self
+    }
+
     /// Export the schema document as a pretty-printed JSON string.
     pub fn export(&self, types: &Types, format: impl Format) -> Result<String, Error> {
         Ok(serde_json::to_string_pretty(
@@ -88,7 +101,12 @@ impl JsonSchema {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let renderer = Renderer::new(self.schema_version, types, self.allow_additional_properties);
+        let renderer = Renderer::new(
+            self.schema_version,
+            types,
+            self.allow_additional_properties,
+            self.number_formats,
+        );
         let (definitions, _) = renderer.render_definitions(&roots)?;
 
         let mut root = Map::new();
@@ -144,6 +162,7 @@ impl JsonSchema {
             self.schema_version,
             mapped,
             self.allow_additional_properties,
+            self.number_formats,
         );
         let (definitions, mut roots) = renderer.render_definitions(&roots)?;
         let root_schema = roots.pop().unwrap_or(Value::Bool(true));

--- a/specta-jsonschema/src/jsonschema.rs
+++ b/specta-jsonschema/src/jsonschema.rs
@@ -16,6 +16,7 @@ pub struct JsonSchema {
     comment: Option<Cow<'static, str>>,
     allow_additional_properties: bool,
     number_formats: bool,
+    string_formats: bool,
 }
 
 impl JsonSchema {
@@ -77,6 +78,20 @@ impl JsonSchema {
         self
     }
 
+    /// Emit JSON Schema string `format` annotations for well-known named
+    /// types, keyed by the same name and module-path identity that
+    /// `specta_typescript::semantic`'s default rules match on:
+    /// `chrono::DateTime` and `jiff::Timestamp` as `date-time`,
+    /// `chrono::NaiveDate` and `jiff::civil::Date` as `date`, `url::Url` as
+    /// `uri`, and `uuid::Uuid` as `uuid`. Only types whose wire form
+    /// satisfies the format are listed (`chrono::NaiveDateTime` serializes
+    /// without an offset, so it carries no format). Off by default so plain
+    /// JSON Schema output is unchanged.
+    pub fn string_formats(mut self, enabled: bool) -> Self {
+        self.string_formats = enabled;
+        self
+    }
+
     /// Export the schema document as a pretty-printed JSON string.
     pub fn export(&self, types: &Types, format: impl Format) -> Result<String, Error> {
         Ok(serde_json::to_string_pretty(
@@ -106,6 +121,7 @@ impl JsonSchema {
             types,
             self.allow_additional_properties,
             self.number_formats,
+            self.string_formats,
         );
         let (definitions, _) = renderer.render_definitions(&roots)?;
 
@@ -163,6 +179,7 @@ impl JsonSchema {
             mapped,
             self.allow_additional_properties,
             self.number_formats,
+            self.string_formats,
         );
         let (definitions, mut roots) = renderer.render_definitions(&roots)?;
         let root_schema = roots.pop().unwrap_or(Value::Bool(true));

--- a/specta-jsonschema/src/render.rs
+++ b/specta-jsonschema/src/render.rs
@@ -48,6 +48,7 @@ pub(crate) struct Renderer<'a> {
     name_counts: BTreeMap<Cow<'static, str>, usize>,
     allow_additional_properties: bool,
     number_formats: bool,
+    string_formats: bool,
 }
 
 impl<'a> Renderer<'a> {
@@ -56,6 +57,7 @@ impl<'a> Renderer<'a> {
         types: &'a Types,
         allow_additional_properties: bool,
         number_formats: bool,
+        string_formats: bool,
     ) -> Self {
         let mut name_counts = BTreeMap::new();
         for ndt in types.into_sorted_iter() {
@@ -72,6 +74,7 @@ impl<'a> Renderer<'a> {
             name_counts,
             allow_additional_properties,
             number_formats,
+            string_formats,
         }
     }
 
@@ -333,7 +336,9 @@ impl<'a> Renderer<'a> {
     ) -> Result<Value, Error> {
         match &reference.inner {
             NamedReferenceType::Inline { dt, .. } => {
-                self.render_datatype(dt, parent_generics, path, depth + 1)
+                let mut schema = self.render_datatype(dt, parent_generics, path, depth + 1)?;
+                self.apply_string_format(reference, &mut schema);
+                Ok(schema)
             }
             NamedReferenceType::Recursive(cycle) => Err(Error::InfiniteRecursiveInlineType {
                 path: path.into(),
@@ -349,6 +354,33 @@ impl<'a> Renderer<'a> {
                 self.ensure_definition(ndt, key.clone(), generics, path)?;
                 Ok(object([("$ref", string(self.ref_path(&key)))]))
             }
+        }
+    }
+
+    /// JSON Schema string formats for well-known named types, keyed by the
+    /// same name and module-path identity that `specta_typescript::semantic`
+    /// matches on. Applied only when the type rendered as a plain string, so
+    /// type overrides and remaps always win. Types whose wire form does not
+    /// satisfy a format (`chrono::NaiveDateTime` has no offset) are absent.
+    fn apply_string_format(&self, reference: &NamedReference, schema: &mut Value) {
+        if !self.string_formats {
+            return;
+        }
+        let Some(ndt) = self.types.get(reference) else {
+            return;
+        };
+        let format = match (ndt.module_path.as_ref(), ndt.name.as_ref()) {
+            ("chrono", "DateTime") | ("jiff", "Timestamp") => "date-time",
+            ("chrono", "NaiveDate") | ("jiff::civil", "Date") => "date",
+            ("url", "Url") => "uri",
+            ("uuid", "Uuid") => "uuid",
+            _ => return,
+        };
+        if let Value::Object(object) = schema
+            && object.get("type").and_then(Value::as_str) == Some("string")
+            && !object.contains_key("format")
+        {
+            object.insert("format".to_string(), string(format));
         }
     }
 

--- a/specta-jsonschema/src/render.rs
+++ b/specta-jsonschema/src/render.rs
@@ -47,6 +47,7 @@ pub(crate) struct Renderer<'a> {
     in_progress_types: Vec<DefinitionSource>,
     name_counts: BTreeMap<Cow<'static, str>, usize>,
     allow_additional_properties: bool,
+    number_formats: bool,
 }
 
 impl<'a> Renderer<'a> {
@@ -54,6 +55,7 @@ impl<'a> Renderer<'a> {
         schema_version: SchemaVersion,
         types: &'a Types,
         allow_additional_properties: bool,
+        number_formats: bool,
     ) -> Self {
         let mut name_counts = BTreeMap::new();
         for ndt in types.into_sorted_iter() {
@@ -69,6 +71,7 @@ impl<'a> Renderer<'a> {
             in_progress_types: Vec::new(),
             name_counts,
             allow_additional_properties,
+            number_formats,
         }
     }
 
@@ -183,7 +186,7 @@ impl<'a> Renderer<'a> {
         }
 
         match dt {
-            DataType::Primitive(primitive) => Ok(primitive_schema(primitive)),
+            DataType::Primitive(primitive) => Ok(self.primitive_schema(primitive)),
             DataType::List(list) => self.render_list(list, generics, path, depth),
             DataType::Map(map) => self.render_map(map, generics, path, depth),
             DataType::Struct(strct) => self.render_struct(strct, generics, path, depth),
@@ -507,7 +510,7 @@ impl<'a> Renderer<'a> {
         depth: usize,
     ) -> Result<Option<Value>, Error> {
         Ok(match dt {
-            DataType::Primitive(Primitive::char) => Some(primitive_schema(&Primitive::char)),
+            DataType::Primitive(Primitive::char) => Some(self.primitive_schema(&Primitive::char)),
             DataType::Primitive(Primitive::str) => None,
             DataType::Primitive(Primitive::bool) => Some(object([(
                 "enum",
@@ -1230,6 +1233,40 @@ fn default_generics(ndt: &NamedDataType) -> Generics {
         }
     }
     generics
+}
+
+impl Renderer<'_> {
+    /// A primitive's schema, with an OpenAPI-style `format` annotation when
+    /// [`number formats`](crate::JsonSchema::number_formats) are enabled.
+    fn primitive_schema(&self, primitive: &Primitive) -> Value {
+        let mut schema = primitive_schema(primitive);
+        if self.number_formats
+            && let Some(format) = number_format(primitive)
+            && let Value::Object(object) = &mut schema
+        {
+            object.insert("format".to_string(), string(format));
+        }
+        schema
+    }
+}
+
+/// The OpenAPI `format` for a numeric primitive: `int32` when every value
+/// fits a signed 32-bit integer, `int64` for wider integers (`u64` included,
+/// by the OpenAPI convention; the bounds state the exact range), and
+/// `float`/`double` for the IEEE 754 sizes. Widths OpenAPI has no name for
+/// get none.
+fn number_format(primitive: &Primitive) -> Option<&'static str> {
+    match primitive {
+        Primitive::i8 | Primitive::i16 | Primitive::i32 | Primitive::u8 | Primitive::u16 => {
+            Some("int32")
+        }
+        Primitive::i64 | Primitive::isize | Primitive::u32 | Primitive::u64 | Primitive::usize => {
+            Some("int64")
+        }
+        Primitive::f32 => Some("float"),
+        Primitive::f64 => Some("double"),
+        _ => None,
+    }
 }
 
 fn primitive_schema(primitive: &Primitive) -> Value {

--- a/specta-jsonschema/src/render.rs
+++ b/specta-jsonschema/src/render.rs
@@ -694,7 +694,13 @@ impl<'a> Renderer<'a> {
                     let field_path = format!("{path}.{name}");
                     let mut schema = self.render_datatype(ty, generics, &field_path, depth + 1)?;
                     self.apply_metadata(&mut schema, None, &field.docs, field.deprecated.as_ref());
-                    properties.insert(name.to_string(), schema);
+                    // A repeated field name overwrites its property, so its
+                    // `required` entry must not repeat either: `required`
+                    // demands unique items in every JSON Schema dialect.
+                    if properties.insert(name.to_string(), schema).is_some() {
+                        required
+                            .retain(|existing: &Value| existing.as_str() != Some(name.as_ref()));
+                    }
                     if !field.optional {
                         required.push(string(name.as_ref()));
                     }

--- a/specta-openapi/Cargo.toml
+++ b/specta-openapi/Cargo.toml
@@ -22,6 +22,7 @@ workspace = true
 [dependencies]
 specta = { version = "=2.0.0-rc.26", path = "../specta" }
 specta-jsonschema = { version = "=0.0.4", path = "../specta-jsonschema" }
+specta-serde = { version = "=0.0.13", path = "../specta-serde" }
 serde = "1"
 serde_json = "1"
 serde_yaml = "0.9"

--- a/specta-openapi/Cargo.toml
+++ b/specta-openapi/Cargo.toml
@@ -22,6 +22,7 @@ workspace = true
 [dependencies]
 specta = { version = "=2.0.0-rc.26", path = "../specta" }
 specta-jsonschema = { version = "=0.0.4", path = "../specta-jsonschema" }
+serde = "1"
 serde_json = "1"
 serde_yaml = "0.9"
 thiserror = "2"

--- a/specta-openapi/Cargo.toml
+++ b/specta-openapi/Cargo.toml
@@ -22,8 +22,6 @@ workspace = true
 [dependencies]
 specta = { version = "=2.0.0-rc.26", path = "../specta" }
 specta-jsonschema = { version = "=0.0.4", path = "../specta-jsonschema" }
-openapiv3 = { version = "2", default-features = false, features = [] }
-indexmap = "2"
 serde_json = "1"
 serde_yaml = "0.9"
 thiserror = "2"

--- a/specta-openapi/src/error.rs
+++ b/specta-openapi/src/error.rs
@@ -8,15 +8,6 @@ pub enum Error {
     #[error(transparent)]
     JsonSchema(#[from] specta_jsonschema::Error),
 
-    /// An exported schema could not be represented by the OpenAPI 3.0 model.
-    #[error("invalid OpenAPI schema component {component:?}: {source}")]
-    InvalidSchema {
-        /// Component being converted.
-        component: String,
-        /// Deserialization error from the strongly typed OpenAPI model.
-        source: serde_json::Error,
-    },
-
     /// A Specta shape cannot be represented exactly by OpenAPI 3.0.
     #[error(
         "OpenAPI 3.0 cannot represent {feature} exactly in component {component:?}. \
@@ -85,6 +76,10 @@ pub enum Error {
     /// A component with the same name already exists in a target document.
     #[error("OpenAPI document already contains schema component {0:?}")]
     DuplicateComponent(String),
+
+    /// A target document is not a JSON object where an object is required.
+    #[error("cannot add components to a non-object OpenAPI document")]
+    InvalidTargetDocument,
 
     /// A directory could not be created.
     #[error("failed to create output directory {path:?}: {source}")]

--- a/specta-openapi/src/error.rs
+++ b/specta-openapi/src/error.rs
@@ -8,6 +8,10 @@ pub enum Error {
     #[error(transparent)]
     JsonSchema(#[from] specta_jsonschema::Error),
 
+    /// The format rejected the type collection.
+    #[error("format error: {0}")]
+    Format(#[from] specta::FormatError),
+
     /// A Specta shape cannot be represented exactly by OpenAPI 3.0.
     #[error(
         "OpenAPI 3.0 cannot represent {feature} exactly in component {component:?}. \

--- a/specta-openapi/src/error.rs
+++ b/specta-openapi/src/error.rs
@@ -82,6 +82,15 @@ pub enum Error {
     #[error("cannot add components to a non-object OpenAPI document")]
     InvalidTargetDocument,
 
+    /// A request-body example could not be serialized to JSON.
+    #[error("failed to serialize the request-body example for {path:?}: {message}")]
+    ExampleSerialization {
+        /// Templated path of the operation carrying the example.
+        path: String,
+        /// Serialization error message.
+        message: String,
+    },
+
     /// A directory could not be created.
     #[error("failed to create output directory {path:?}: {source}")]
     CreateDir {

--- a/specta-openapi/src/error.rs
+++ b/specta-openapi/src/error.rs
@@ -12,7 +12,8 @@ pub enum Error {
     #[error(
         "OpenAPI 3.0 cannot represent {feature} exactly in component {component:?}. \
          Export with SchemaMode::Compatible to emit the closest schema and keep the exact \
-         constraints in x-specta-* extensions."
+         constraints in x-specta-* extensions, or target OasVersion::V3_1, whose schema \
+         dialect expresses this natively."
     )]
     UnsupportedSchemaFeature {
         /// Component containing the unsupported shape.

--- a/specta-openapi/src/lib.rs
+++ b/specta-openapi/src/lib.rs
@@ -41,8 +41,8 @@
 //! approximation and retain the original constraints in `x-specta-*`
 //! extensions. This affects nullable references — an `Option<T>` over a named
 //! type, which OpenAPI 3.0 cannot mark `nullable` beside a `$ref` — along with
-//! exact 64-bit integer bounds, null-only types, heterogeneous tuples,
-//! constrained map keys, and closed flattened intersections.
+//! null-only types, heterogeneous tuples, constrained map keys, and closed
+//! flattened intersections.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
@@ -59,5 +59,4 @@ mod transform;
 
 pub use error::Error;
 pub use openapi::{OpenApi, OutputFormat, SchemaMode};
-pub use openapiv3::{Components, OpenAPI, ReferenceOr, Schema, SecurityScheme};
 pub use operation::{Method, Operation, Param};

--- a/specta-openapi/src/lib.rs
+++ b/specta-openapi/src/lib.rs
@@ -59,5 +59,5 @@ mod transform;
 
 pub use error::Error;
 pub use openapi::{OpenApi, OutputFormat, SchemaMode};
-pub use openapiv3::{Components, OpenAPI, ReferenceOr, Schema};
-pub use operation::{Method, Operation};
+pub use openapiv3::{Components, OpenAPI, ReferenceOr, Schema, SecurityScheme};
+pub use operation::{Method, Operation, Param};

--- a/specta-openapi/src/lib.rs
+++ b/specta-openapi/src/lib.rs
@@ -35,6 +35,15 @@
 //! assert!(document.contains("User"));
 //! ```
 //!
+//! # Generator compatibility
+//!
+//! Some lowerings exist for the toolchains that consume the document rather
+//! than for the specification: numeric schemas carry `format` hints, plain
+//! string enums compact to the `type: string, enum: [...]` form, and integer
+//! bounds beyond the signed 64-bit range are carried in `x-specta-*`
+//! extensions, since mainstream generators parse bounds into signed 64-bit
+//! integers and silently wrap anything wider.
+//!
 //! # OpenAPI 3.0 compatibility
 //!
 //! OpenAPI 3.1's schema dialect is full JSON Schema, so every Specta shape is

--- a/specta-openapi/src/lib.rs
+++ b/specta-openapi/src/lib.rs
@@ -35,6 +35,17 @@
 //! assert!(document.contains("User"));
 //! ```
 //!
+//! # Phase-aware operations
+//!
+//! Operations resolve their types per side: request bodies and parameters
+//! describe what the server deserializes, responses what it serializes.
+//! Under [`specta_serde::Format`] the phases are unified and nothing changes;
+//! export with [`specta_serde::PhasesFormat`] and a type whose serialize and
+//! deserialize shapes diverge - `#[serde(skip_serializing_if)]`, one-sided
+//! renames - references its own projection on each side, so both directions
+//! of the contract are stated exactly. Annotation-driven generators carry one
+//! schema per type and cannot make this distinction.
+//!
 //! # Generator compatibility
 //!
 //! Some lowerings exist for the toolchains that consume the document rather

--- a/specta-openapi/src/lib.rs
+++ b/specta-openapi/src/lib.rs
@@ -1,8 +1,10 @@
-//! [OpenAPI 3.0](https://spec.openapis.org/oas/v3.0.3) schema exporter for
+//! [OpenAPI](https://spec.openapis.org/oas/) schema exporter for
 //! [Specta](specta).
 //!
 //! The exporter turns a [`specta::Types`] collection into a valid OpenAPI
-//! document whose reusable schemas live in `components.schemas`.
+//! document whose reusable schemas live in `components.schemas`. Documents
+//! target OpenAPI 3.1 by default; select [`OasVersion::V3_0`] to emit for
+//! OpenAPI 3.0 consumers.
 //!
 //! # Usage
 //!
@@ -35,14 +37,16 @@
 //!
 //! # OpenAPI 3.0 compatibility
 //!
-//! OpenAPI 3.0 uses an older, restricted JSON Schema dialect. The default
-//! [`SchemaMode::Strict`] returns an error for structural schema features which
-//! the specification cannot express. Opt into [`SchemaMode::Compatible`] to emit a useful
-//! approximation and retain the original constraints in `x-specta-*`
-//! extensions. This affects nullable references — an `Option<T>` over a named
-//! type, which OpenAPI 3.0 cannot mark `nullable` beside a `$ref` — along with
-//! null-only types, heterogeneous tuples, constrained map keys, and closed
-//! flattened intersections.
+//! OpenAPI 3.1's schema dialect is full JSON Schema, so every Specta shape is
+//! expressible in it. OpenAPI 3.0 uses an older, restricted dialect: under
+//! [`OasVersion::V3_0`] the default [`SchemaMode::Strict`] returns an error
+//! for structural schema features which that specification cannot express,
+//! and [`SchemaMode::Compatible`] emits a useful approximation instead,
+//! retaining the original constraints in `x-specta-*` extensions. This
+//! affects nullable references — an `Option<T>` over a named type, which
+//! OpenAPI 3.0 cannot mark `nullable` beside a `$ref` — along with null-only
+//! types, heterogeneous tuples, constrained map keys, and closed flattened
+//! intersections.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
@@ -58,5 +62,5 @@ mod resolve;
 mod transform;
 
 pub use error::Error;
-pub use openapi::{OpenApi, OutputFormat, SchemaMode};
+pub use openapi::{OasVersion, OpenApi, OutputFormat, SchemaMode};
 pub use operation::{Method, Operation, Param};

--- a/specta-openapi/src/openapi.rs
+++ b/specta-openapi/src/openapi.rs
@@ -1,12 +1,9 @@
-use std::{borrow::Cow, path::Path};
+use std::{borrow::Cow, collections::BTreeMap, path::Path};
 
-use indexmap::IndexMap;
-use openapiv3::{
-    Components, Contact, Info, OpenAPI, Paths, ReferenceOr, SecurityScheme, Server, Tag,
-};
+use serde_json::{Map, Value, json};
 use specta::{Format, Types};
 
-use crate::{Error, operation::Operation, resolve::resolve, transform::components};
+use crate::{Error, operation::Operation, resolve::resolve};
 
 /// How shapes unsupported by OpenAPI 3.0's schema dialect are handled.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -29,6 +26,24 @@ pub enum OutputFormat {
     Yaml,
 }
 
+#[derive(Debug, Clone)]
+struct Server {
+    url: String,
+    description: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct Tag {
+    name: String,
+    description: String,
+}
+
+#[derive(Debug, Clone)]
+struct Contact {
+    name: String,
+    url: String,
+}
+
 /// OpenAPI 3.0 schema exporter.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
@@ -42,7 +57,7 @@ pub struct OpenApi {
     servers: Vec<Server>,
     tags: Vec<Tag>,
     contact: Option<Contact>,
-    security_schemes: IndexMap<String, SecurityScheme>,
+    security_schemes: BTreeMap<String, Value>,
 }
 
 impl Default for OpenApi {
@@ -57,7 +72,7 @@ impl Default for OpenApi {
             servers: Vec::new(),
             tags: Vec::new(),
             contact: None,
-            security_schemes: IndexMap::new(),
+            security_schemes: BTreeMap::new(),
         }
     }
 }
@@ -90,7 +105,7 @@ impl OpenApi {
     pub fn server(mut self, url: impl Into<String>) -> Self {
         self.servers.push(Server {
             url: url.into(),
-            ..Default::default()
+            description: None,
         });
         self
     }
@@ -104,7 +119,6 @@ impl OpenApi {
         self.servers.push(Server {
             url: url.into(),
             description: Some(description.into()),
-            ..Default::default()
         });
         self
     }
@@ -112,9 +126,8 @@ impl OpenApi {
     /// Configure the API contact in the generated document's `info` object.
     pub fn contact(mut self, name: impl Into<String>, url: impl Into<String>) -> Self {
         self.contact = Some(Contact {
-            name: Some(name.into()),
-            url: Some(url.into()),
-            ..Default::default()
+            name: name.into(),
+            url: url.into(),
         });
         self
     }
@@ -124,17 +137,17 @@ impl OpenApi {
     pub fn tag(mut self, name: impl Into<String>, description: impl Into<String>) -> Self {
         self.tags.push(Tag {
             name: name.into(),
-            description: Some(description.into()),
-            ..Default::default()
+            description: description.into(),
         });
         self
     }
 
     /// Register a security scheme under `name`, which operations reference
-    /// with [`Operation::security`]. The full [`SecurityScheme`] surface is
-    /// [`openapiv3`]'s; [`bearer_security_scheme`](Self::bearer_security_scheme)
+    /// with [`Operation::security`]. The scheme is given as a
+    /// [Security Scheme Object](https://spec.openapis.org/oas/v3.0.3#security-scheme-object)
+    /// in JSON; [`bearer_security_scheme`](Self::bearer_security_scheme)
     /// covers the common token case.
-    pub fn security_scheme(mut self, name: impl Into<String>, scheme: SecurityScheme) -> Self {
+    pub fn security_scheme(mut self, name: impl Into<String>, scheme: Value) -> Self {
         self.security_schemes.insert(name.into(), scheme);
         self
     }
@@ -147,12 +160,11 @@ impl OpenApi {
     ) -> Self {
         self.security_scheme(
             name,
-            SecurityScheme::HTTP {
-                scheme: "bearer".to_string(),
-                bearer_format: Some(bearer_format.into()),
-                description: None,
-                extensions: IndexMap::new(),
-            },
+            json!({
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": bearer_format.into(),
+            }),
         )
     }
 
@@ -205,71 +217,117 @@ impl OpenApi {
         self
     }
 
-    /// Export the supplied types as a complete OpenAPI 3.0 document.
-    pub fn export_document(&self, types: &Types, format: impl Format) -> Result<OpenAPI, Error> {
-        let (components, resolved) = resolve(types, &self.operations, format, self.schema_mode)?;
+    /// Export the supplied types as a complete OpenAPI document, as JSON.
+    pub fn export_document(&self, types: &Types, format: impl Format) -> Result<Value, Error> {
+        let (schemas, resolved) = resolve(types, &self.operations, format, self.schema_mode)?;
         let paths = if self.operations.is_empty() {
-            Paths::default()
+            Value::Object(Map::new())
         } else {
             crate::paths::paths(&self.operations, &resolved)?
         };
 
-        let mut components = components;
-        for (name, scheme) in &self.security_schemes {
-            components
-                .security_schemes
-                .insert(name.clone(), ReferenceOr::Item(scheme.clone()));
+        let mut components = Map::new();
+        if !schemas.is_empty() {
+            components.insert(
+                "schemas".to_string(),
+                Value::Object(schemas.into_iter().collect()),
+            );
+        }
+        if !self.security_schemes.is_empty() {
+            components.insert(
+                "securitySchemes".to_string(),
+                Value::Object(self.security_schemes.clone().into_iter().collect()),
+            );
         }
 
-        Ok(OpenAPI {
-            openapi: "3.0.3".to_string(),
-            info: Info {
-                title: self.title.to_string(),
-                description: self.description.as_ref().map(ToString::to_string),
-                version: self.version.to_string(),
-                contact: self.contact.clone(),
-                ..Default::default()
-            },
-            servers: self.servers.clone(),
-            tags: self.tags.clone(),
-            paths,
-            components: Some(components),
-            ..Default::default()
-        })
+        let mut info = Map::new();
+        info.insert("title".to_string(), json!(self.title));
+        info.insert("version".to_string(), json!(self.version));
+        if let Some(description) = &self.description {
+            info.insert("description".to_string(), json!(description));
+        }
+        if let Some(contact) = &self.contact {
+            info.insert(
+                "contact".to_string(),
+                json!({ "name": contact.name, "url": contact.url }),
+            );
+        }
+
+        let mut document = Map::new();
+        document.insert("openapi".to_string(), json!("3.0.3"));
+        document.insert("info".to_string(), Value::Object(info));
+        if !self.servers.is_empty() {
+            document.insert(
+                "servers".to_string(),
+                Value::Array(
+                    self.servers
+                        .iter()
+                        .map(|server| match &server.description {
+                            Some(description) => {
+                                json!({ "url": server.url, "description": description })
+                            }
+                            None => json!({ "url": server.url }),
+                        })
+                        .collect(),
+                ),
+            );
+        }
+        if !self.tags.is_empty() {
+            document.insert(
+                "tags".to_string(),
+                Value::Array(
+                    self.tags
+                        .iter()
+                        .map(|tag| json!({ "name": tag.name, "description": tag.description }))
+                        .collect(),
+                ),
+            );
+        }
+        document.insert("paths".to_string(), paths);
+        document.insert("components".to_string(), Value::Object(components));
+        Ok(Value::Object(document))
     }
 
-    /// Export only the reusable `components` object for merging into an
+    /// Export only the reusable schema components for merging into an
     /// application-owned OpenAPI document.
     pub fn export_components(
         &self,
         types: &Types,
         format: impl Format,
-    ) -> Result<Components, Error> {
-        components(types, format, self.schema_mode)
+    ) -> Result<BTreeMap<String, Value>, Error> {
+        crate::transform::components(types, format, self.schema_mode)
     }
 
     /// Add exported schemas to an existing document without replacing any
     /// existing schema component.
+    ///
+    /// The target is any OpenAPI document as JSON, whichever tool produced it.
     pub fn add_to_document(
         &self,
-        document: &mut OpenAPI,
+        document: &mut Value,
         types: &Types,
         format: impl Format,
     ) -> Result<(), Error> {
         let exported = self.export_components(types, format)?;
-        let target = &mut document
-            .components
-            .get_or_insert_with(Components::default)
-            .schemas;
 
-        if let Some(name) = exported
-            .schemas
-            .keys()
-            .find(|name| target.contains_key(*name))
-        {
+        let root = document
+            .as_object_mut()
+            .ok_or(Error::InvalidTargetDocument)?;
+        let components = root
+            .entry("components")
+            .or_insert_with(|| Value::Object(Map::new()))
+            .as_object_mut()
+            .ok_or(Error::InvalidTargetDocument)?;
+        let target = components
+            .entry("schemas")
+            .or_insert_with(|| Value::Object(Map::new()))
+            .as_object_mut()
+            .ok_or(Error::InvalidTargetDocument)?;
+
+        if let Some(name) = exported.keys().find(|name| target.contains_key(*name)) {
             return Err(Error::DuplicateComponent(name.clone()));
         }
-        target.extend(exported.schemas);
+        target.extend(exported);
         Ok(())
     }
 

--- a/specta-openapi/src/openapi.rs
+++ b/specta-openapi/src/openapi.rs
@@ -5,7 +5,38 @@ use specta::{Format, Types};
 
 use crate::{Error, operation::Operation, resolve::resolve};
 
+/// OpenAPI Specification version of the emitted document.
+///
+/// OpenAPI 3.1's schema dialect is full JSON Schema, so every Specta shape is
+/// expressible in it and [`SchemaMode`] has no effect. OpenAPI 3.0 uses an
+/// older, restricted dialect whose unrepresentable shapes [`SchemaMode`]
+/// governs. Patch digits carry no meaning of their own — tooling is told to
+/// ignore them — so each variant emits the version string its consumers have
+/// seen most.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum OasVersion {
+    /// OpenAPI 3.0, emitted as `3.0.3`, for consumers that predate 3.1.
+    V3_0,
+    /// OpenAPI 3.1, emitted as `3.1.0`.
+    #[default]
+    V3_1,
+}
+
+impl OasVersion {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            OasVersion::V3_0 => "3.0.3",
+            OasVersion::V3_1 => "3.1.0",
+        }
+    }
+}
+
 /// How shapes unsupported by OpenAPI 3.0's schema dialect are handled.
+///
+/// Applies to [`OasVersion::V3_0`] alone: OpenAPI 3.1's dialect is full JSON
+/// Schema, where every Specta shape is expressible, so under it both modes
+/// emit the same document.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum SchemaMode {
     /// Return an error for unsupported structural OpenAPI 3.0 schema features.
@@ -44,7 +75,7 @@ struct Contact {
     url: String,
 }
 
-/// OpenAPI 3.0 schema exporter.
+/// OpenAPI schema exporter.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct OpenApi {
@@ -52,6 +83,7 @@ pub struct OpenApi {
     version: Cow<'static, str>,
     description: Option<Cow<'static, str>>,
     output_format: OutputFormat,
+    oas_version: OasVersion,
     schema_mode: SchemaMode,
     operations: Vec<Operation>,
     servers: Vec<Server>,
@@ -67,6 +99,7 @@ impl Default for OpenApi {
             version: Cow::Borrowed("0.0.0"),
             description: None,
             output_format: OutputFormat::Json,
+            oas_version: OasVersion::default(),
             schema_mode: SchemaMode::Strict,
             operations: Vec::new(),
             servers: Vec::new(),
@@ -174,6 +207,13 @@ impl OpenApi {
         self
     }
 
+    /// Configure the OpenAPI Specification version of the emitted document.
+    /// Documents target OpenAPI 3.1 unless told otherwise; see [`OasVersion`].
+    pub fn oas_version(mut self, oas_version: OasVersion) -> Self {
+        self.oas_version = oas_version;
+        self
+    }
+
     /// Configure whether OpenAPI 3.0-incompatible shapes are approximated or
     /// rejected. See [`SchemaMode`].
     pub fn schema_mode(mut self, schema_mode: SchemaMode) -> Self {
@@ -219,7 +259,13 @@ impl OpenApi {
 
     /// Export the supplied types as a complete OpenAPI document, as JSON.
     pub fn export_document(&self, types: &Types, format: impl Format) -> Result<Value, Error> {
-        let (schemas, resolved) = resolve(types, &self.operations, format, self.schema_mode)?;
+        let (schemas, resolved) = resolve(
+            types,
+            &self.operations,
+            format,
+            self.schema_mode,
+            self.oas_version,
+        )?;
         let paths = if self.operations.is_empty() {
             Value::Object(Map::new())
         } else {
@@ -254,7 +300,7 @@ impl OpenApi {
         }
 
         let mut document = Map::new();
-        document.insert("openapi".to_string(), json!("3.0.3"));
+        document.insert("openapi".to_string(), json!(self.oas_version.as_str()));
         document.insert("info".to_string(), Value::Object(info));
         if !self.servers.is_empty() {
             document.insert(
@@ -295,7 +341,7 @@ impl OpenApi {
         types: &Types,
         format: impl Format,
     ) -> Result<BTreeMap<String, Value>, Error> {
-        crate::transform::components(types, format, self.schema_mode)
+        crate::transform::components(types, format, self.schema_mode, self.oas_version)
     }
 
     /// Add exported schemas to an existing document without replacing any

--- a/specta-openapi/src/openapi.rs
+++ b/specta-openapi/src/openapi.rs
@@ -182,7 +182,9 @@ impl OpenApi {
         self
     }
 
-    /// Configure the API license with its SPDX identifier.
+    /// Configure the API license with its SPDX identifier. The `identifier`
+    /// field is OpenAPI 3.1's; under [`OasVersion::V3_0`] the name alone is
+    /// emitted.
     pub fn license_spdx(mut self, name: impl Into<String>, identifier: impl Into<String>) -> Self {
         self.license = Some(License {
             name: name.into(),
@@ -327,11 +329,13 @@ impl OpenApi {
         if let Some(license) = &self.license {
             info.insert(
                 "license".to_string(),
-                match &license.identifier {
-                    Some(identifier) => {
+                match (&license.identifier, self.oas_version) {
+                    (Some(identifier), OasVersion::V3_1) => {
                         json!({ "name": license.name, "identifier": identifier })
                     }
-                    None => json!({ "name": license.name }),
+                    // `identifier` is an OpenAPI 3.1 field; 3.0's license
+                    // object carries the name alone.
+                    _ => json!({ "name": license.name }),
                 },
             );
         }

--- a/specta-openapi/src/openapi.rs
+++ b/specta-openapi/src/openapi.rs
@@ -1,6 +1,9 @@
 use std::{borrow::Cow, path::Path};
 
-use openapiv3::{Components, Info, OpenAPI, Paths};
+use indexmap::IndexMap;
+use openapiv3::{
+    Components, Contact, Info, OpenAPI, Paths, ReferenceOr, SecurityScheme, Server, Tag,
+};
 use specta::{Format, Types};
 
 use crate::{Error, operation::Operation, resolve::resolve, transform::components};
@@ -36,6 +39,10 @@ pub struct OpenApi {
     output_format: OutputFormat,
     schema_mode: SchemaMode,
     operations: Vec<Operation>,
+    servers: Vec<Server>,
+    tags: Vec<Tag>,
+    contact: Option<Contact>,
+    security_schemes: IndexMap<String, SecurityScheme>,
 }
 
 impl Default for OpenApi {
@@ -47,6 +54,10 @@ impl Default for OpenApi {
             output_format: OutputFormat::Json,
             schema_mode: SchemaMode::Strict,
             operations: Vec::new(),
+            servers: Vec::new(),
+            tags: Vec::new(),
+            contact: None,
+            security_schemes: IndexMap::new(),
         }
     }
 }
@@ -73,6 +84,76 @@ impl OpenApi {
     pub fn description(mut self, description: impl Into<Cow<'static, str>>) -> Self {
         self.description = Some(description.into());
         self
+    }
+
+    /// Add a server the API is reachable on, in the document's `servers` list.
+    pub fn server(mut self, url: impl Into<String>) -> Self {
+        self.servers.push(Server {
+            url: url.into(),
+            ..Default::default()
+        });
+        self
+    }
+
+    /// Add a server with a human-readable description.
+    pub fn server_described(
+        mut self,
+        url: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self {
+        self.servers.push(Server {
+            url: url.into(),
+            description: Some(description.into()),
+            ..Default::default()
+        });
+        self
+    }
+
+    /// Configure the API contact in the generated document's `info` object.
+    pub fn contact(mut self, name: impl Into<String>, url: impl Into<String>) -> Self {
+        self.contact = Some(Contact {
+            name: Some(name.into()),
+            url: Some(url.into()),
+            ..Default::default()
+        });
+        self
+    }
+
+    /// Add a tag with a description, which generators and documentation use
+    /// to group operations declared with [`Operation::tag`].
+    pub fn tag(mut self, name: impl Into<String>, description: impl Into<String>) -> Self {
+        self.tags.push(Tag {
+            name: name.into(),
+            description: Some(description.into()),
+            ..Default::default()
+        });
+        self
+    }
+
+    /// Register a security scheme under `name`, which operations reference
+    /// with [`Operation::security`]. The full [`SecurityScheme`] surface is
+    /// [`openapiv3`]'s; [`bearer_security_scheme`](Self::bearer_security_scheme)
+    /// covers the common token case.
+    pub fn security_scheme(mut self, name: impl Into<String>, scheme: SecurityScheme) -> Self {
+        self.security_schemes.insert(name.into(), scheme);
+        self
+    }
+
+    /// Register an HTTP bearer-token security scheme under `name`.
+    pub fn bearer_security_scheme(
+        self,
+        name: impl Into<String>,
+        bearer_format: impl Into<String>,
+    ) -> Self {
+        self.security_scheme(
+            name,
+            SecurityScheme::HTTP {
+                scheme: "bearer".to_string(),
+                bearer_format: Some(bearer_format.into()),
+                description: None,
+                extensions: IndexMap::new(),
+            },
+        )
     }
 
     /// Configure JSON or YAML serialization.
@@ -133,14 +214,24 @@ impl OpenApi {
             crate::paths::paths(&self.operations, &resolved)?
         };
 
+        let mut components = components;
+        for (name, scheme) in &self.security_schemes {
+            components
+                .security_schemes
+                .insert(name.clone(), ReferenceOr::Item(scheme.clone()));
+        }
+
         Ok(OpenAPI {
             openapi: "3.0.3".to_string(),
             info: Info {
                 title: self.title.to_string(),
                 description: self.description.as_ref().map(ToString::to_string),
                 version: self.version.to_string(),
+                contact: self.contact.clone(),
                 ..Default::default()
             },
+            servers: self.servers.clone(),
+            tags: self.tags.clone(),
             paths,
             components: Some(components),
             ..Default::default()

--- a/specta-openapi/src/openapi.rs
+++ b/specta-openapi/src/openapi.rs
@@ -75,6 +75,12 @@ struct Contact {
     url: String,
 }
 
+#[derive(Debug, Clone)]
+struct License {
+    name: String,
+    identifier: Option<String>,
+}
+
 /// OpenAPI schema exporter.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
@@ -89,6 +95,7 @@ pub struct OpenApi {
     servers: Vec<Server>,
     tags: Vec<Tag>,
     contact: Option<Contact>,
+    license: Option<License>,
     security_schemes: BTreeMap<String, Value>,
 }
 
@@ -105,6 +112,7 @@ impl Default for OpenApi {
             servers: Vec::new(),
             tags: Vec::new(),
             contact: None,
+            license: None,
             security_schemes: BTreeMap::new(),
         }
     }
@@ -161,6 +169,24 @@ impl OpenApi {
         self.contact = Some(Contact {
             name: name.into(),
             url: url.into(),
+        });
+        self
+    }
+
+    /// Configure the API license in the generated document's `info` object.
+    pub fn license(mut self, name: impl Into<String>) -> Self {
+        self.license = Some(License {
+            name: name.into(),
+            identifier: None,
+        });
+        self
+    }
+
+    /// Configure the API license with its SPDX identifier.
+    pub fn license_spdx(mut self, name: impl Into<String>, identifier: impl Into<String>) -> Self {
+        self.license = Some(License {
+            name: name.into(),
+            identifier: Some(identifier.into()),
         });
         self
     }
@@ -296,6 +322,17 @@ impl OpenApi {
             info.insert(
                 "contact".to_string(),
                 json!({ "name": contact.name, "url": contact.url }),
+            );
+        }
+        if let Some(license) = &self.license {
+            info.insert(
+                "license".to_string(),
+                match &license.identifier {
+                    Some(identifier) => {
+                        json!({ "name": license.name, "identifier": identifier })
+                    }
+                    None => json!({ "name": license.name }),
+                },
             );
         }
 

--- a/specta-openapi/src/operation.rs
+++ b/specta-openapi/src/operation.rs
@@ -39,7 +39,83 @@ pub(crate) struct Parameter {
     pub(crate) location: ParameterLocation,
     pub(crate) required: bool,
     pub(crate) description: Option<Cow<'static, str>>,
+    pub(crate) example: Option<serde_json::Value>,
     pub(crate) ty: Body,
+}
+
+/// A parameter under construction: [`Param::path`], [`Param::query`], or
+/// [`Param::header`] pick the location and type, and the builder methods add
+/// what the bare [`Operation`] conveniences cannot say.
+///
+/// ```rust
+/// # use specta_openapi::{Operation, Param};
+/// # use serde_json::json;
+/// let operation = Operation::get("/v1/weather/forecast")
+///     .parameter(
+///         Param::query::<f64>("lat")
+///             .required()
+///             .description("Latitude, WGS84 degrees, -90 to 90")
+///             .example(json!(35.0)),
+///     );
+/// ```
+#[derive(Debug, Clone)]
+pub struct Param(pub(crate) Parameter);
+
+impl Param {
+    /// A templated path parameter of type `T`. Path parameters are always
+    /// required.
+    pub fn path<T: Type>(name: impl Into<Cow<'static, str>>) -> Self {
+        Self(Parameter {
+            name: name.into(),
+            location: ParameterLocation::Path,
+            required: true,
+            description: None,
+            example: None,
+            ty: capture::<T>(),
+        })
+    }
+
+    /// A query parameter of type `T`, optional unless [`required`](Self::required).
+    pub fn query<T: Type>(name: impl Into<Cow<'static, str>>) -> Self {
+        Self(Parameter {
+            name: name.into(),
+            location: ParameterLocation::Query,
+            required: false,
+            description: None,
+            example: None,
+            ty: capture::<T>(),
+        })
+    }
+
+    /// A header parameter of type `T`, optional unless [`required`](Self::required).
+    pub fn header<T: Type>(name: impl Into<Cow<'static, str>>) -> Self {
+        Self(Parameter {
+            name: name.into(),
+            location: ParameterLocation::Header,
+            required: false,
+            description: None,
+            example: None,
+            ty: capture::<T>(),
+        })
+    }
+
+    /// Marks the parameter required.
+    pub fn required(mut self) -> Self {
+        self.0.required = true;
+        self
+    }
+
+    /// Sets the parameter's description.
+    pub fn description(mut self, description: impl Into<Cow<'static, str>>) -> Self {
+        self.0.description = Some(description.into());
+        self
+    }
+
+    /// Sets the parameter's example value.
+    pub fn example(mut self, example: serde_json::Value) -> Self {
+        self.0.example = Some(example);
+        self
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -54,8 +130,14 @@ pub(crate) struct Body {
 pub(crate) struct Response {
     pub(crate) status: u16,
     pub(crate) description: Cow<'static, str>,
+    pub(crate) content_type: Option<Cow<'static, str>>,
     pub(crate) body: Option<Body>,
 }
+
+/// One way a caller may satisfy an operation's security: scheme names (as
+/// registered on the document) to their required scopes. An empty requirement
+/// means the operation also works anonymously.
+pub(crate) type SecurityRequirement = Vec<(Cow<'static, str>, Vec<String>)>;
 
 /// A single endpoint: one method on one path.
 ///
@@ -85,6 +167,7 @@ pub struct Operation {
     pub(crate) parameters: Vec<Parameter>,
     pub(crate) request_body: Option<Body>,
     pub(crate) responses: Vec<Response>,
+    pub(crate) security: Vec<SecurityRequirement>,
 }
 
 impl Operation {
@@ -103,6 +186,7 @@ impl Operation {
             parameters: Vec::new(),
             request_body: None,
             responses: Vec::new(),
+            security: Vec::new(),
         }
     }
 
@@ -159,38 +243,25 @@ impl Operation {
     ///
     /// `T` is what the extractor parses the segment into, so `/users/{id}` served by a
     /// `Path<u32>` is `path_param::<u32>("id")` and exports as an integer.
-    pub fn path_param<T: Type>(mut self, name: impl Into<Cow<'static, str>>) -> Self {
-        self.parameters.push(Parameter {
-            name: name.into(),
-            location: ParameterLocation::Path,
-            required: true,
-            description: None,
-            ty: capture::<T>(),
-        });
-        self
+    pub fn path_param<T: Type>(self, name: impl Into<Cow<'static, str>>) -> Self {
+        self.parameter(Param::path::<T>(name))
     }
 
     /// Declares an optional query parameter of type `T`.
-    pub fn query_param<T: Type>(mut self, name: impl Into<Cow<'static, str>>) -> Self {
-        self.parameters.push(Parameter {
-            name: name.into(),
-            location: ParameterLocation::Query,
-            required: false,
-            description: None,
-            ty: capture::<T>(),
-        });
-        self
+    pub fn query_param<T: Type>(self, name: impl Into<Cow<'static, str>>) -> Self {
+        self.parameter(Param::query::<T>(name))
     }
 
     /// Declares an optional header parameter of type `T`.
-    pub fn header_param<T: Type>(mut self, name: impl Into<Cow<'static, str>>) -> Self {
-        self.parameters.push(Parameter {
-            name: name.into(),
-            location: ParameterLocation::Header,
-            required: false,
-            description: None,
-            ty: capture::<T>(),
-        });
+    pub fn header_param<T: Type>(self, name: impl Into<Cow<'static, str>>) -> Self {
+        self.parameter(Param::header::<T>(name))
+    }
+
+    /// Declares a parameter built with [`Param`], which can say what the bare
+    /// conveniences cannot: required query parameters, descriptions, and
+    /// example values.
+    pub fn parameter(mut self, param: Param) -> Self {
+        self.parameters.push(param.0);
         self
     }
 
@@ -212,8 +283,51 @@ impl Operation {
         self.responses.push(Response {
             status,
             description: description.into(),
+            content_type: None,
             body: Some(capture::<T>()),
         });
+        self
+    }
+
+    /// Declares a response body of `T` for `status` served with a content
+    /// type other than `application/json`, such as RFC 9457's
+    /// `application/problem+json`.
+    pub fn response_as<T: Type>(
+        mut self,
+        status: u16,
+        description: impl Into<Cow<'static, str>>,
+        content_type: impl Into<Cow<'static, str>>,
+    ) -> Self {
+        self.responses.push(Response {
+            status,
+            description: description.into(),
+            content_type: Some(content_type.into()),
+            body: Some(capture::<T>()),
+        });
+        self
+    }
+
+    /// Adds one way a caller may satisfy this operation's security: scheme
+    /// names (as registered on the document) to their required scopes. Each
+    /// call adds an alternative; a caller needs to satisfy only one.
+    pub fn security<N: Into<Cow<'static, str>>>(
+        mut self,
+        requirement: impl IntoIterator<Item = (N, Vec<String>)>,
+    ) -> Self {
+        self.security.push(
+            requirement
+                .into_iter()
+                .map(|(name, scopes)| (name.into(), scopes))
+                .collect(),
+        );
+        self
+    }
+
+    /// Also allows the operation to be called with no credentials at all: the
+    /// empty security requirement, which makes any [`security`](Self::security)
+    /// alternatives optional.
+    pub fn security_optional(mut self) -> Self {
+        self.security.push(Vec::new());
         self
     }
 
@@ -239,6 +353,7 @@ impl Operation {
         self.responses.push(Response {
             status,
             description: description.into(),
+            content_type: None,
             body: None,
         });
         self

--- a/specta-openapi/src/operation.rs
+++ b/specta-openapi/src/operation.rs
@@ -347,16 +347,21 @@ impl Operation {
         self
     }
 
-    /// Every type this operation references, with Rust's name for it.
-    pub(crate) fn referenced_types(&self) -> impl Iterator<Item = (&DataType, &'static str)> {
+    /// Every request-side type this operation references - the request body
+    /// and the parameters, the shapes the server deserializes.
+    pub(crate) fn request_types(&self) -> impl Iterator<Item = (&DataType, &'static str)> {
         self.request_body
             .iter()
-            .chain(
-                self.responses
-                    .iter()
-                    .filter_map(|response| response.body.as_ref()),
-            )
             .chain(self.parameters.iter().map(|parameter| &parameter.ty))
+            .map(|body| (&body.dt, body.type_name))
+    }
+
+    /// Every response-side type this operation references - the shapes the
+    /// server serializes.
+    pub(crate) fn response_types(&self) -> impl Iterator<Item = (&DataType, &'static str)> {
+        self.responses
+            .iter()
+            .filter_map(|response| response.body.as_ref())
             .map(|body| (&body.dt, body.type_name))
     }
 

--- a/specta-openapi/src/operation.rs
+++ b/specta-openapi/src/operation.rs
@@ -166,6 +166,9 @@ pub struct Operation {
     pub(crate) tags: Vec<Cow<'static, str>>,
     pub(crate) parameters: Vec<Parameter>,
     pub(crate) request_body: Option<Body>,
+    /// Serialized eagerly; a failure is carried as the error message and
+    /// raised loudly at export rather than dropped.
+    pub(crate) request_body_example: Option<Result<serde_json::Value, String>>,
     pub(crate) responses: Vec<Response>,
     pub(crate) security: Vec<SecurityRequirement>,
 }
@@ -185,6 +188,7 @@ impl Operation {
             tags: Vec::new(),
             parameters: Vec::new(),
             request_body: None,
+            request_body_example: None,
             responses: Vec::new(),
             security: Vec::new(),
         }
@@ -268,6 +272,18 @@ impl Operation {
     /// Declares the JSON request body as `T`.
     pub fn request_body<T: Type>(mut self) -> Self {
         self.request_body = Some(capture::<T>());
+        self
+    }
+
+    /// Declares the JSON request body as `T` with an example: a real value of
+    /// the body type, serialized through the same serde path as production
+    /// traffic and carried in the media type's `example`. The compiler keeps
+    /// the example true to the schema — it cannot drift the way an untyped
+    /// annotation can.
+    pub fn request_body_with_example<T: Type + serde::Serialize>(mut self, example: T) -> Self {
+        self.request_body = Some(capture::<T>());
+        self.request_body_example =
+            Some(serde_json::to_value(&example).map_err(|error| error.to_string()));
         self
     }
 

--- a/specta-openapi/src/paths.rs
+++ b/specta-openapi/src/paths.rs
@@ -9,7 +9,7 @@ use indexmap::IndexMap;
 use openapiv3::{
     MediaType, Operation as OpenApiOperation, Parameter as OpenApiParameter, ParameterData,
     ParameterSchemaOrContent, PathItem, Paths, ReferenceOr, RequestBody, Response, Responses,
-    StatusCode,
+    SecurityRequirement, StatusCode,
 };
 
 const JSON: &str = "application/json";
@@ -60,11 +60,12 @@ fn lower(operation: &Operation, resolved: &Resolved) -> Result<OpenApiOperation,
 
     let mut responses = Responses::default();
     for response in &operation.responses {
+        let content_type = response.content_type.as_deref().unwrap_or(JSON);
         responses.responses.insert(
             StatusCode::Code(response.status),
             ReferenceOr::Item(Response {
                 description: response.description.to_string(),
-                content: content_of(response.body.as_ref(), resolved)?,
+                content: content_of(response.body.as_ref(), content_type, resolved)?,
                 ..Default::default()
             }),
         );
@@ -72,7 +73,7 @@ fn lower(operation: &Operation, resolved: &Resolved) -> Result<OpenApiOperation,
 
     let request_body = match &operation.request_body {
         Some(body) => Some(ReferenceOr::Item(RequestBody {
-            content: content_of(Some(body), resolved)?,
+            content: content_of(Some(body), JSON, resolved)?,
             required: true,
             ..Default::default()
         })),
@@ -91,12 +92,25 @@ fn lower(operation: &Operation, resolved: &Resolved) -> Result<OpenApiOperation,
             .collect::<Result<Vec<_>, _>>()?,
         request_body,
         responses,
+        security: (!operation.security.is_empty()).then(|| {
+            operation
+                .security
+                .iter()
+                .map(|requirement| {
+                    requirement
+                        .iter()
+                        .map(|(name, scopes)| (name.to_string(), scopes.clone()))
+                        .collect::<SecurityRequirement>()
+                })
+                .collect()
+        }),
         ..Default::default()
     })
 }
 
 fn content_of(
     body: Option<&Body>,
+    content_type: &str,
     resolved: &Resolved,
 ) -> Result<IndexMap<String, MediaType>, Error> {
     let Some(body) = body else {
@@ -106,7 +120,7 @@ fn content_of(
         .get(&body.dt)
         .ok_or(Error::UnresolvedOperationTypes)?;
     Ok(IndexMap::from_iter([(
-        JSON.to_string(),
+        content_type.to_string(),
         MediaType {
             schema: Some(schema.clone()),
             ..Default::default()
@@ -128,7 +142,7 @@ fn parameter(
         required: parameter.required,
         deprecated: None,
         format: ParameterSchemaOrContent::Schema(schema.clone()),
-        example: None,
+        example: parameter.example.clone(),
         examples: IndexMap::new(),
         explode: None,
         extensions: IndexMap::new(),

--- a/specta-openapi/src/paths.rs
+++ b/specta-openapi/src/paths.rs
@@ -1,167 +1,162 @@
 //! Lowering of [`Operation`]s into the document's `paths` object.
 
+use serde_json::{Map, Value, json};
+
 use crate::{
     Error,
     operation::{Body, Method, Operation, ParameterLocation},
     resolve::Resolved,
 };
-use indexmap::IndexMap;
-use openapiv3::{
-    MediaType, Operation as OpenApiOperation, Parameter as OpenApiParameter, ParameterData,
-    ParameterSchemaOrContent, PathItem, Paths, ReferenceOr, RequestBody, Response, Responses,
-    SecurityRequirement, StatusCode,
-};
 
 const JSON: &str = "application/json";
 
-pub(crate) fn paths(operations: &[Operation], resolved: &Resolved) -> Result<Paths, Error> {
-    let mut paths: IndexMap<String, ReferenceOr<PathItem>> = IndexMap::new();
+pub(crate) fn paths(operations: &[Operation], resolved: &Resolved) -> Result<Value, Error> {
+    let mut paths = Map::new();
 
     for operation in operations {
         let lowered = lower(operation, resolved)?;
-        let entry = paths
+        let item = paths
             .entry(operation.path.to_string())
-            .or_insert_with(|| ReferenceOr::Item(PathItem::default()));
-        let ReferenceOr::Item(item) = entry else {
+            .or_insert_with(|| Value::Object(Map::new()));
+        let Some(item) = item.as_object_mut() else {
             continue;
         };
 
-        let slot = match operation.method {
-            Method::Get => &mut item.get,
-            Method::Post => &mut item.post,
-            Method::Put => &mut item.put,
-            Method::Patch => &mut item.patch,
-            Method::Delete => &mut item.delete,
-            Method::Head => &mut item.head,
-            Method::Options => &mut item.options,
-            Method::Trace => &mut item.trace,
-        };
-        if slot.is_some() {
+        let method = method_key(operation.method);
+        if item.contains_key(method) {
             return Err(Error::DuplicateOperation {
-                method: format!("{:?}", operation.method).to_uppercase(),
+                method: method.to_uppercase(),
                 path: operation.path.to_string(),
             });
         }
-        *slot = Some(lowered);
+        item.insert(method.to_string(), lowered);
     }
 
-    Ok(Paths {
-        paths,
-        ..Default::default()
-    })
+    Ok(Value::Object(paths))
 }
 
-fn lower(operation: &Operation, resolved: &Resolved) -> Result<OpenApiOperation, Error> {
+fn method_key(method: Method) -> &'static str {
+    match method {
+        Method::Get => "get",
+        Method::Post => "post",
+        Method::Put => "put",
+        Method::Patch => "patch",
+        Method::Delete => "delete",
+        Method::Head => "head",
+        Method::Options => "options",
+        Method::Trace => "trace",
+    }
+}
+
+fn lower(operation: &Operation, resolved: &Resolved) -> Result<Value, Error> {
     if operation.responses.is_empty() {
         return Err(Error::OperationWithoutResponses {
             path: operation.path.to_string(),
         });
     }
 
-    let mut responses = Responses::default();
+    let mut responses = Map::new();
     for response in &operation.responses {
-        let content_type = response.content_type.as_deref().unwrap_or(JSON);
-        responses.responses.insert(
-            StatusCode::Code(response.status),
-            ReferenceOr::Item(Response {
-                description: response.description.to_string(),
-                content: content_of(response.body.as_ref(), content_type, resolved)?,
-                ..Default::default()
+        let mut object = Map::new();
+        object.insert("description".to_string(), json!(response.description));
+        if let Some(body) = &response.body {
+            let content_type = response.content_type.as_deref().unwrap_or(JSON);
+            object.insert(
+                "content".to_string(),
+                json!({ content_type: { "schema": schema_of(body, resolved)? } }),
+            );
+        }
+        responses.insert(response.status.to_string(), Value::Object(object));
+    }
+
+    let mut object = Map::new();
+    if !operation.tags.is_empty() {
+        object.insert("tags".to_string(), json!(operation.tags));
+    }
+    if let Some(summary) = &operation.summary {
+        object.insert("summary".to_string(), json!(summary));
+    }
+    if let Some(description) = &operation.description {
+        object.insert("description".to_string(), json!(description));
+    }
+    if let Some(operation_id) = &operation.operation_id {
+        object.insert("operationId".to_string(), json!(operation_id));
+    }
+    if !operation.parameters.is_empty() {
+        object.insert(
+            "parameters".to_string(),
+            Value::Array(
+                operation
+                    .parameters
+                    .iter()
+                    .map(|parameter| self::parameter(parameter, resolved))
+                    .collect::<Result<_, _>>()?,
+            ),
+        );
+    }
+    if let Some(body) = &operation.request_body {
+        object.insert(
+            "requestBody".to_string(),
+            json!({
+                "content": { JSON: { "schema": schema_of(body, resolved)? } },
+                "required": true,
             }),
         );
     }
+    object.insert("responses".to_string(), Value::Object(responses));
+    if !operation.security.is_empty() {
+        object.insert(
+            "security".to_string(),
+            Value::Array(
+                operation
+                    .security
+                    .iter()
+                    .map(|requirement| {
+                        Value::Object(
+                            requirement
+                                .iter()
+                                .map(|(name, scopes)| (name.to_string(), json!(scopes)))
+                                .collect(),
+                        )
+                    })
+                    .collect(),
+            ),
+        );
+    }
 
-    let request_body = match &operation.request_body {
-        Some(body) => Some(ReferenceOr::Item(RequestBody {
-            content: content_of(Some(body), JSON, resolved)?,
-            required: true,
-            ..Default::default()
-        })),
-        None => None,
-    };
-
-    Ok(OpenApiOperation {
-        tags: operation.tags.iter().map(ToString::to_string).collect(),
-        summary: operation.summary.as_ref().map(ToString::to_string),
-        description: operation.description.as_ref().map(ToString::to_string),
-        operation_id: operation.operation_id.as_ref().map(ToString::to_string),
-        parameters: operation
-            .parameters
-            .iter()
-            .map(|p| parameter(p, resolved))
-            .collect::<Result<Vec<_>, _>>()?,
-        request_body,
-        responses,
-        security: (!operation.security.is_empty()).then(|| {
-            operation
-                .security
-                .iter()
-                .map(|requirement| {
-                    requirement
-                        .iter()
-                        .map(|(name, scopes)| (name.to_string(), scopes.clone()))
-                        .collect::<SecurityRequirement>()
-                })
-                .collect()
-        }),
-        ..Default::default()
-    })
-}
-
-fn content_of(
-    body: Option<&Body>,
-    content_type: &str,
-    resolved: &Resolved,
-) -> Result<IndexMap<String, MediaType>, Error> {
-    let Some(body) = body else {
-        return Ok(IndexMap::new());
-    };
-    let schema = resolved
-        .get(&body.dt)
-        .ok_or(Error::UnresolvedOperationTypes)?;
-    Ok(IndexMap::from_iter([(
-        content_type.to_string(),
-        MediaType {
-            schema: Some(schema.clone()),
-            ..Default::default()
-        },
-    )]))
+    Ok(Value::Object(object))
 }
 
 /// Lowers a parameter, carrying the schema of whatever the extractor parses it into.
-fn parameter(
-    parameter: &crate::operation::Parameter,
-    resolved: &Resolved,
-) -> Result<ReferenceOr<OpenApiParameter>, Error> {
-    let schema = resolved
-        .get(&parameter.ty.dt)
-        .ok_or(Error::UnresolvedOperationTypes)?;
-    let data = ParameterData {
-        name: parameter.name.to_string(),
-        description: parameter.description.as_ref().map(ToString::to_string),
-        required: parameter.required,
-        deprecated: None,
-        format: ParameterSchemaOrContent::Schema(schema.clone()),
-        example: parameter.example.clone(),
-        examples: IndexMap::new(),
-        explode: None,
-        extensions: IndexMap::new(),
-    };
+fn parameter(parameter: &crate::operation::Parameter, resolved: &Resolved) -> Result<Value, Error> {
+    let mut object = Map::new();
+    object.insert("name".to_string(), json!(parameter.name));
+    object.insert(
+        "in".to_string(),
+        json!(match parameter.location {
+            ParameterLocation::Path => "path",
+            ParameterLocation::Query => "query",
+            ParameterLocation::Header => "header",
+        }),
+    );
+    if let Some(description) = &parameter.description {
+        object.insert("description".to_string(), json!(description));
+    }
+    if parameter.required {
+        object.insert("required".to_string(), json!(true));
+    }
+    if let Some(example) = &parameter.example {
+        object.insert("example".to_string(), example.clone());
+    }
+    object.insert("schema".to_string(), schema_of(&parameter.ty, resolved)?);
+    Ok(Value::Object(object))
+}
 
-    Ok(ReferenceOr::Item(match parameter.location {
-        ParameterLocation::Path => OpenApiParameter::Path {
-            parameter_data: data,
-            style: Default::default(),
-        },
-        ParameterLocation::Query => OpenApiParameter::Query {
-            parameter_data: data,
-            allow_reserved: false,
-            style: Default::default(),
-            allow_empty_value: None,
-        },
-        ParameterLocation::Header => OpenApiParameter::Header {
-            parameter_data: data,
-            style: Default::default(),
-        },
-    }))
+/// What the exporter emitted for a declared type: a `$ref` when it has a
+/// component, its schema in place when it does not.
+fn schema_of(body: &Body, resolved: &Resolved) -> Result<Value, Error> {
+    resolved
+        .get(&body.dt)
+        .cloned()
+        .ok_or(Error::UnresolvedOperationTypes)
 }

--- a/specta-openapi/src/paths.rs
+++ b/specta-openapi/src/paths.rs
@@ -95,10 +95,21 @@ fn lower(operation: &Operation, resolved: &Resolved) -> Result<Value, Error> {
         );
     }
     if let Some(body) = &operation.request_body {
+        let mut media = Map::new();
+        media.insert("schema".to_string(), schema_of(body, resolved)?);
+        if let Some(example) = &operation.request_body_example {
+            let example = example
+                .clone()
+                .map_err(|message| Error::ExampleSerialization {
+                    path: operation.path.to_string(),
+                    message,
+                })?;
+            media.insert("example".to_string(), example);
+        }
         object.insert(
             "requestBody".to_string(),
             json!({
-                "content": { JSON: { "schema": schema_of(body, resolved)? } },
+                "content": { JSON: media },
                 "required": true,
             }),
         );

--- a/specta-openapi/src/paths.rs
+++ b/specta-openapi/src/paths.rs
@@ -63,7 +63,7 @@ fn lower(operation: &Operation, resolved: &Resolved) -> Result<Value, Error> {
             let content_type = response.content_type.as_deref().unwrap_or(JSON);
             object.insert(
                 "content".to_string(),
-                json!({ content_type: { "schema": schema_of(body, resolved)? } }),
+                json!({ content_type: { "schema": response_schema_of(body, resolved)? } }),
             );
         }
         responses.insert(response.status.to_string(), Value::Object(object));
@@ -96,7 +96,7 @@ fn lower(operation: &Operation, resolved: &Resolved) -> Result<Value, Error> {
     }
     if let Some(body) = &operation.request_body {
         let mut media = Map::new();
-        media.insert("schema".to_string(), schema_of(body, resolved)?);
+        media.insert("schema".to_string(), request_schema_of(body, resolved)?);
         if let Some(example) = &operation.request_body_example {
             let example = example
                 .clone()
@@ -159,15 +159,28 @@ fn parameter(parameter: &crate::operation::Parameter, resolved: &Resolved) -> Re
     if let Some(example) = &parameter.example {
         object.insert("example".to_string(), example.clone());
     }
-    object.insert("schema".to_string(), schema_of(&parameter.ty, resolved)?);
+    object.insert(
+        "schema".to_string(),
+        request_schema_of(&parameter.ty, resolved)?,
+    );
     Ok(Value::Object(object))
 }
 
-/// What the exporter emitted for a declared type: a `$ref` when it has a
-/// component, its schema in place when it does not.
-fn schema_of(body: &Body, resolved: &Resolved) -> Result<Value, Error> {
+/// What the exporter emitted for a request-side type - a body or parameter,
+/// resolved through the deserialize phase: a `$ref` when it has a component,
+/// its schema in place when it does not.
+fn request_schema_of(body: &Body, resolved: &Resolved) -> Result<Value, Error> {
     resolved
-        .get(&body.dt)
+        .request(&body.dt)
+        .cloned()
+        .ok_or(Error::UnresolvedOperationTypes)
+}
+
+/// What the exporter emitted for a response-side type, resolved through the
+/// serialize phase.
+fn response_schema_of(body: &Body, resolved: &Resolved) -> Result<Value, Error> {
+    resolved
+        .response(&body.dt)
         .cloned()
         .ok_or(Error::UnresolvedOperationTypes)
 }

--- a/specta-openapi/src/resolve.rs
+++ b/specta-openapi/src/resolve.rs
@@ -19,7 +19,7 @@ use specta::{
     datatype::{DataType, Field, NamedDataType, NamedReference, Reference, Struct},
 };
 
-use crate::{Error, SchemaMode, operation::Operation, transform::components};
+use crate::{Error, OasVersion, SchemaMode, operation::Operation, transform::components};
 
 /// Name of the probe definition. Carries a prefix no derived type will produce, so it cannot collide
 /// with a real definition and change how the real ones are named.
@@ -38,6 +38,7 @@ pub(crate) fn resolve(
     operations: &[Operation],
     format: impl Format,
     mode: SchemaMode,
+    version: OasVersion,
 ) -> Result<(BTreeMap<String, Value>, Resolved), Error> {
     let mut referenced: Vec<DataType> = Vec::new();
     for operation in operations {
@@ -59,7 +60,7 @@ pub(crate) fn resolve(
     }
 
     if referenced.is_empty() {
-        return Ok((components(types, format, mode)?, HashMap::new()));
+        return Ok((components(types, format, mode, version)?, HashMap::new()));
     }
 
     let mut probe_types = types.clone();
@@ -72,7 +73,7 @@ pub(crate) fn resolve(
         ndt.ty = Some(body.clone());
     });
 
-    let mut components = components(&probe_types, format, mode)?;
+    let mut components = components(&probe_types, format, mode, version)?;
     let Some(probe) = components.remove(PROBE) else {
         return Err(Error::UnresolvedOperationTypes);
     };

--- a/specta-openapi/src/resolve.rs
+++ b/specta-openapi/src/resolve.rs
@@ -10,7 +10,14 @@
 //! field per referenced type is exported alongside the real ones, and whatever the exporter emits
 //! for each field is the answer: a `$ref` for a named type, an inline schema for anything else. The
 //! probe is dropped from the components afterwards.
+//!
+//! Resolution is phase-aware: request-side types (bodies and parameters, the shapes the server
+//! deserializes) resolve through the deserialize phase, response-side types through the serialize
+//! phase. Under [`specta_serde::Format`] the phases are unified and both resolve identically;
+//! under [`specta_serde::PhasesFormat`] a type whose phases diverge resolves to its
+//! `_Serialize`/`_Deserialize` projection per use — the format is the switch, not a knob here.
 
+use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
 
 use serde_json::Value;
@@ -18,6 +25,7 @@ use specta::{
     Format, Types,
     datatype::{DataType, Field, NamedDataType, NamedReference, Reference, Struct},
 };
+use specta_serde::{Phase, select_phase_datatype};
 
 use crate::{Error, OasVersion, SchemaMode, operation::Operation, transform::components};
 
@@ -25,11 +33,45 @@ use crate::{Error, OasVersion, SchemaMode, operation::Operation, transform::comp
 /// with a real definition and change how the real ones are named.
 const PROBE: &str = "__specta_openapi_probe";
 
-/// What an operation's type is exported as: a `$ref` to a component, or a schema in place —
-/// whichever the exporter emitted for it.
-pub(crate) type Resolved = HashMap<DataType, Value>;
+/// What an operation's types are exported as, per side: a `$ref` to a component, or a schema in
+/// place — whichever the exporter emitted. Keyed by the type as the operation declared it; the
+/// phase projection is internal.
+pub(crate) struct Resolved {
+    request: HashMap<DataType, Value>,
+    response: HashMap<DataType, Value>,
+}
 
-/// Exports `types`, and resolves every type referenced by `operations`.
+impl Resolved {
+    pub(crate) fn request(&self, dt: &DataType) -> Option<&Value> {
+        self.request.get(dt)
+    }
+
+    pub(crate) fn response(&self, dt: &DataType) -> Option<&Value> {
+        self.response.get(dt)
+    }
+}
+
+/// A format whose collection mapping has already been applied. Mapping runs exactly once however
+/// many exports resolution performs; per-datatype mapping still delegates to the real format.
+struct Premapped<F>(F);
+
+impl<F: Format> Format for Premapped<F> {
+    fn map_types(&'_ self, types: &Types) -> Result<Cow<'_, Types>, specta::FormatError> {
+        // The returned borrow is tied to `&self`, not `types`, so identity
+        // still clones - the same cost class as the probe collection clone.
+        Ok(Cow::Owned(types.clone()))
+    }
+
+    fn map_type(
+        &'_ self,
+        types: &Types,
+        dt: &DataType,
+    ) -> Result<Cow<'_, DataType>, specta::FormatError> {
+        self.0.map_type(types, dt)
+    }
+}
+
+/// Exports `types`, and resolves every type referenced by `operations` per side.
 ///
 /// Returns the components with the probe removed, so the caller exports exactly what it would have
 /// without one.
@@ -40,32 +82,60 @@ pub(crate) fn resolve(
     mode: SchemaMode,
     version: OasVersion,
 ) -> Result<(BTreeMap<String, Value>, Resolved), Error> {
-    let mut referenced: Vec<DataType> = Vec::new();
+    let mapped = format.map_types(types)?.into_owned();
+
+    // (original declaration, phase projection, Rust name) per side, deduplicated by projection.
+    let mut request: Vec<(DataType, DataType)> = Vec::new();
+    let mut response: Vec<(DataType, DataType)> = Vec::new();
+    let mut probe_fields: Vec<DataType> = Vec::new();
     for operation in operations {
-        for (dt, type_name) in operation.referenced_types() {
-            // A named type is exported as a component, so it has to be in the collection being
-            // exported. Anything else is written in place and needs no registration.
-            if let DataType::Reference(Reference::Named(reference)) = dt
-                && is_component(reference)
-                && types.get(reference).is_none()
-            {
-                return Err(Error::UnregisteredOperationType {
-                    type_name: type_name.to_string(),
-                });
-            }
-            if !referenced.contains(dt) {
-                referenced.push(dt.clone());
+        for (phase, roles, side) in [
+            (
+                Phase::Deserialize,
+                operation.request_types().collect::<Vec<_>>(),
+                &mut request,
+            ),
+            (
+                Phase::Serialize,
+                operation.response_types().collect::<Vec<_>>(),
+                &mut response,
+            ),
+        ] {
+            for (dt, type_name) in roles {
+                let selected = select_phase_datatype(dt, &mapped, phase);
+                // A named type is exported as a component, so it has to be in the collection being
+                // exported. Anything else is written in place and needs no registration.
+                if let DataType::Reference(Reference::Named(reference)) = &selected
+                    && is_component(reference)
+                    && mapped.get(reference).is_none()
+                {
+                    return Err(Error::UnregisteredOperationType {
+                        type_name: type_name.to_string(),
+                    });
+                }
+                if !probe_fields.contains(&selected) {
+                    probe_fields.push(selected.clone());
+                }
+                if !side.iter().any(|(original, _)| original == dt) {
+                    side.push((dt.clone(), selected));
+                }
             }
         }
     }
 
-    if referenced.is_empty() {
-        return Ok((components(types, format, mode, version)?, HashMap::new()));
+    if probe_fields.is_empty() {
+        return Ok((
+            components(&mapped, Premapped(format), mode, version)?,
+            Resolved {
+                request: HashMap::new(),
+                response: HashMap::new(),
+            },
+        ));
     }
 
-    let mut probe_types = types.clone();
+    let mut probe_types = mapped.clone();
     let mut probe = Struct::named();
-    for (index, dt) in referenced.iter().enumerate() {
+    for (index, dt) in probe_fields.iter().enumerate() {
         probe = probe.field(field_name(index), Field::new(dt.clone()));
     }
     let body = probe.build();
@@ -73,18 +143,34 @@ pub(crate) fn resolve(
         ndt.ty = Some(body.clone());
     });
 
-    let mut components = components(&probe_types, format, mode, version)?;
+    let mut components = components(&probe_types, Premapped(format), mode, version)?;
     let Some(probe) = components.remove(PROBE) else {
         return Err(Error::UnresolvedOperationTypes);
     };
 
-    let mut resolved = Resolved::new();
-    for (index, dt) in referenced.into_iter().enumerate() {
-        let property = probe
+    let schema_for = |selected: &DataType| -> Result<Value, Error> {
+        let index = probe_fields
+            .iter()
+            .position(|candidate| candidate == selected)
+            .ok_or(Error::UnresolvedOperationTypes)?;
+        probe
             .get("properties")
             .and_then(|properties| properties.get(field_name(index)))
-            .ok_or(Error::UnresolvedOperationTypes)?;
-        resolved.insert(dt, property.clone());
+            .cloned()
+            .ok_or(Error::UnresolvedOperationTypes)
+    };
+
+    let mut resolved = Resolved {
+        request: HashMap::new(),
+        response: HashMap::new(),
+    };
+    for (original, selected) in request {
+        let schema = schema_for(&selected)?;
+        resolved.request.insert(original, schema);
+    }
+    for (original, selected) in response {
+        let schema = schema_for(&selected)?;
+        resolved.response.insert(original, schema);
     }
 
     Ok((components, resolved))

--- a/specta-openapi/src/resolve.rs
+++ b/specta-openapi/src/resolve.rs
@@ -11,9 +11,8 @@
 //! for each field is the answer: a `$ref` for a named type, an inline schema for anything else. The
 //! probe is dropped from the components afterwards.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
-use openapiv3::{Components, ReferenceOr, Schema};
 use serde_json::Value;
 use specta::{
     Format, Types,
@@ -26,8 +25,9 @@ use crate::{Error, SchemaMode, operation::Operation, transform::components};
 /// with a real definition and change how the real ones are named.
 const PROBE: &str = "__specta_openapi_probe";
 
-/// What an operation's type is exported as: a reference to a component, or a schema in place.
-pub(crate) type Resolved = HashMap<DataType, ReferenceOr<Schema>>;
+/// What an operation's type is exported as: a `$ref` to a component, or a schema in place —
+/// whichever the exporter emitted for it.
+pub(crate) type Resolved = HashMap<DataType, Value>;
 
 /// Exports `types`, and resolves every type referenced by `operations`.
 ///
@@ -38,7 +38,7 @@ pub(crate) fn resolve(
     operations: &[Operation],
     format: impl Format,
     mode: SchemaMode,
-) -> Result<(Components, Resolved), Error> {
+) -> Result<(BTreeMap<String, Value>, Resolved), Error> {
     let mut referenced: Vec<DataType> = Vec::new();
     for operation in operations {
         for (dt, type_name) in operation.referenced_types() {
@@ -73,18 +73,17 @@ pub(crate) fn resolve(
     });
 
     let mut components = components(&probe_types, format, mode)?;
-    let Some(ReferenceOr::Item(schema)) = components.schemas.shift_remove(PROBE) else {
+    let Some(probe) = components.remove(PROBE) else {
         return Err(Error::UnresolvedOperationTypes);
     };
 
-    let probe = serde_json::to_value(&schema)?;
     let mut resolved = Resolved::new();
     for (index, dt) in referenced.into_iter().enumerate() {
         let property = probe
             .get("properties")
             .and_then(|properties| properties.get(field_name(index)))
             .ok_or(Error::UnresolvedOperationTypes)?;
-        resolved.insert(dt, schema_of(property)?);
+        resolved.insert(dt, property.clone());
     }
 
     Ok((components, resolved))
@@ -99,21 +98,6 @@ fn is_component(reference: &NamedReference) -> bool {
         reference.inner,
         specta::datatype::NamedReferenceType::Reference { .. }
     )
-}
-
-/// Reads back what the exporter emitted for one probe field.
-fn schema_of(property: &Value) -> Result<ReferenceOr<Schema>, Error> {
-    if let Some(reference) = property.get("$ref").and_then(Value::as_str) {
-        return Ok(ReferenceOr::Reference {
-            reference: reference.to_string(),
-        });
-    }
-    serde_json::from_value(property.clone())
-        .map(ReferenceOr::Item)
-        .map_err(|source| Error::InvalidSchema {
-            component: PROBE.to_string(),
-            source,
-        })
 }
 
 fn field_name(index: usize) -> String {

--- a/specta-openapi/src/transform.rs
+++ b/specta-openapi/src/transform.rs
@@ -182,6 +182,9 @@ fn transform_object(
 
     compact_string_enum(&mut schema);
 
+    preserve_wide_integer_bound(&mut schema, "minimum");
+    preserve_wide_integer_bound(&mut schema, "maximum");
+
     if version == OasVersion::V3_0 && schema.get("type").and_then(Value::as_str) == Some("null") {
         if mode == SchemaMode::Strict {
             return Err(unsupported(component, "null-only types"));
@@ -288,6 +291,24 @@ fn transform_object(
         }
     }
     Ok(Value::Object(schema))
+}
+
+/// Bounds beyond the signed 64-bit range are carried in `x-specta-*`
+/// extensions in both dialects. Mainstream generator toolchains parse bounds
+/// into signed 64-bit integers, and a bound that silently wraps -
+/// openapi-generator renders a `u64::MAX` maximum as `maximum: -1` - is worse
+/// than one carried out of band. The bound such values state is vacuous as a
+/// constraint, so nothing enforceable is lost.
+fn preserve_wide_integer_bound(schema: &mut Map<String, Value>, keyword: &str) {
+    let Some(Value::Number(bound)) = schema.get(keyword) else {
+        return;
+    };
+    if bound.as_i64().is_some() || bound.as_u64().is_none() {
+        return;
+    }
+    if let Some(bound) = schema.remove(keyword) {
+        schema.insert(format!("x-specta-{keyword}"), bound);
+    }
 }
 
 fn move_unsupported_keyword(

--- a/specta-openapi/src/transform.rs
+++ b/specta-openapi/src/transform.rs
@@ -3,12 +3,13 @@ use std::collections::BTreeMap;
 use serde_json::{Map, Value, json};
 use specta::{Format, Types};
 
-use crate::{Error, SchemaMode};
+use crate::{Error, OasVersion, SchemaMode};
 
 pub(crate) fn components(
     types: &Types,
     format: impl Format,
     mode: SchemaMode,
+    version: OasVersion,
 ) -> Result<BTreeMap<String, Value>, Error> {
     let mut schema = specta_jsonschema::JsonSchema::default()
         // OpenAPI generators map numeric formats to language types.
@@ -41,7 +42,10 @@ pub(crate) fn components(
             .cloned()
             .unwrap_or_else(|| component_name(&name));
         rewrite_component_refs(&mut schema, &references);
-        let schema = component_schema(transform(schema, &component_name, mode)?);
+        let mut schema = transform(schema, &component_name, mode, version)?;
+        if version == OasVersion::V3_0 {
+            schema = component_schema(schema);
+        }
         components.insert(component_name, schema);
     }
     Ok(components)
@@ -115,17 +119,23 @@ fn component_schema(value: Value) -> Value {
     Value::Object(schema)
 }
 
-fn transform(value: Value, component: &str, mode: SchemaMode) -> Result<Value, Error> {
+fn transform(
+    value: Value,
+    component: &str,
+    mode: SchemaMode,
+    version: OasVersion,
+) -> Result<Value, Error> {
     Ok(match value {
-        Value::Bool(true) => json!({}),
-        Value::Bool(false) => json!({ "not": {} }),
+        // JSON Schema's boolean schemas are valid 3.1; 3.0 requires objects.
+        Value::Bool(true) if version == OasVersion::V3_0 => json!({}),
+        Value::Bool(false) if version == OasVersion::V3_0 => json!({ "not": {} }),
         Value::Array(values) => Value::Array(
             values
                 .into_iter()
-                .map(|value| transform(value, component, mode))
+                .map(|value| transform(value, component, mode, version))
                 .collect::<Result<_, _>>()?,
         ),
-        Value::Object(schema) => transform_object(schema, component, mode)?,
+        Value::Object(schema) => transform_object(schema, component, mode, version)?,
         value => value,
     })
 }
@@ -134,25 +144,28 @@ fn transform_object(
     mut schema: Map<String, Value>,
     component: &str,
     mode: SchemaMode,
+    version: OasVersion,
 ) -> Result<Value, Error> {
     schema.remove("$schema");
     schema.remove("$comment");
-    move_unsupported_keyword(
-        &mut schema,
-        "propertyNames",
-        "x-specta-property-names",
-        "constrained map keys",
-        component,
-        mode,
-    )?;
-    move_unsupported_keyword(
-        &mut schema,
-        "unevaluatedProperties",
-        "x-specta-unevaluated-properties",
-        "closed flattened intersections",
-        component,
-        mode,
-    )?;
+    if version == OasVersion::V3_0 {
+        move_unsupported_keyword(
+            &mut schema,
+            "propertyNames",
+            "x-specta-property-names",
+            "constrained map keys",
+            component,
+            mode,
+        )?;
+        move_unsupported_keyword(
+            &mut schema,
+            "unevaluatedProperties",
+            "x-specta-unevaluated-properties",
+            "closed flattened intersections",
+            component,
+            mode,
+        )?;
+    }
     schema.remove("additionalItems");
 
     if let Some(Value::String(reference)) = schema.get_mut("$ref") {
@@ -161,13 +174,15 @@ fn transform_object(
             .replacen("#/definitions/", "#/components/schemas/", 1);
     }
 
-    if let Some(constant) = schema.remove("const") {
+    if version == OasVersion::V3_0
+        && let Some(constant) = schema.remove("const")
+    {
         schema.insert("enum".to_string(), Value::Array(vec![constant]));
     }
 
     compact_string_enum(&mut schema);
 
-    if schema.get("type").and_then(Value::as_str) == Some("null") {
+    if version == OasVersion::V3_0 && schema.get("type").and_then(Value::as_str) == Some("null") {
         if mode == SchemaMode::Strict {
             return Err(unsupported(component, "null-only types"));
         }
@@ -178,77 +193,99 @@ fn transform_object(
         schema.insert("x-specta-type".to_string(), Value::String("null".into()));
     }
 
-    // Collapse nullable unions before recursively transforming their branches.
-    // Otherwise strict mode rejects the raw `{ "type": "null" }` branch before
-    // it can be represented by OpenAPI 3.0's `nullable` keyword.
-    while collapse_nullable_any_of(&mut schema) {}
+    if version == OasVersion::V3_0 {
+        // Collapse nullable unions before recursively transforming their branches.
+        // Otherwise strict mode rejects the raw `{ "type": "null" }` branch before
+        // it can be represented by OpenAPI 3.0's `nullable` keyword.
+        while collapse_nullable_any_of(&mut schema) {}
 
-    let prefix_items = schema.remove("prefixItems").or_else(|| {
-        schema
-            .get("items")
-            .is_some_and(Value::is_array)
-            .then(|| schema.remove("items"))
-            .flatten()
-    });
-    if let Some(Value::Array(items)) = prefix_items {
-        let heterogeneous = items
-            .first()
-            .is_some_and(|first| items.iter().skip(1).any(|item| item != first));
-        if heterogeneous && mode == SchemaMode::Strict {
-            return Err(unsupported(component, "heterogeneous positional tuples"));
+        let prefix_items = schema.remove("prefixItems").or_else(|| {
+            schema
+                .get("items")
+                .is_some_and(Value::is_array)
+                .then(|| schema.remove("items"))
+                .flatten()
+        });
+        if let Some(Value::Array(items)) = prefix_items {
+            let heterogeneous = items
+                .first()
+                .is_some_and(|first| items.iter().skip(1).any(|item| item != first));
+            if heterogeneous && mode == SchemaMode::Strict {
+                return Err(unsupported(component, "heterogeneous positional tuples"));
+            }
+            let mut items = items
+                .into_iter()
+                .map(|value| transform(value, component, mode, version))
+                .collect::<Result<Vec<_>, _>>()?;
+            if heterogeneous {
+                schema.insert(
+                    "x-specta-prefix-items".to_string(),
+                    Value::Array(items.clone()),
+                );
+            }
+            let item = match items.len() {
+                0 => json!({}),
+                1 => items.pop().unwrap_or_else(|| json!({})),
+                _ if heterogeneous => json!({ "oneOf": items }),
+                _ => items.pop().unwrap_or_else(|| json!({})),
+            };
+            schema.insert("items".to_string(), item);
         }
-        let mut items = items
-            .into_iter()
-            .map(|value| transform(value, component, mode))
-            .collect::<Result<Vec<_>, _>>()?;
-        if heterogeneous {
-            schema.insert(
-                "x-specta-prefix-items".to_string(),
-                Value::Array(items.clone()),
-            );
-        }
-        let item = match items.len() {
-            0 => json!({}),
-            1 => items.pop().unwrap_or_else(|| json!({})),
-            _ if heterogeneous => json!({ "oneOf": items }),
-            _ => items.pop().unwrap_or_else(|| json!({})),
-        };
-        schema.insert("items".to_string(), item);
+    } else if schema.get("items").is_some_and(Value::is_array)
+        && !schema.contains_key("prefixItems")
+        && let Some(items) = schema.remove("items")
+    {
+        // 2020-12 spells positional items `prefixItems`.
+        schema.insert("prefixItems".to_string(), items);
     }
 
     for key in ["items", "not"] {
         if let Some(value) = schema.get_mut(key) {
-            *value = transform(value.take(), component, mode)?;
+            *value = transform(value.take(), component, mode, version)?;
         }
     }
     if let Some(value @ Value::Object(_)) = schema.get_mut("additionalProperties") {
-        *value = transform(value.take(), component, mode)?;
+        *value = transform(value.take(), component, mode, version)?;
     }
     for key in ["properties"] {
         if let Some(Value::Object(values)) = schema.get_mut(key) {
             for value in values.values_mut() {
-                *value = transform(value.take(), component, mode)?;
+                *value = transform(value.take(), component, mode, version)?;
             }
         }
     }
     for key in ["oneOf", "allOf", "anyOf"] {
         if let Some(Value::Array(values)) = schema.get_mut(key) {
             for value in values {
-                *value = transform(value.take(), component, mode)?;
+                *value = transform(value.take(), component, mode, version)?;
+            }
+        }
+    }
+    if version == OasVersion::V3_1 {
+        if let Some(Value::Array(values)) = schema.get_mut("prefixItems") {
+            for value in values {
+                *value = transform(value.take(), component, mode, version)?;
+            }
+        }
+        for key in ["propertyNames", "unevaluatedProperties"] {
+            if let Some(value) = schema.get_mut(key) {
+                *value = transform(value.take(), component, mode, version)?;
             }
         }
     }
 
-    collapse_nullable_any_of(&mut schema);
-    wrap_reference_with_siblings(&mut schema);
-    if mode == SchemaMode::Strict
-        && schema.get("nullable") == Some(&Value::Bool(true))
-        && !schema.contains_key("type")
-    {
-        return Err(unsupported(
-            component,
-            "nullable references or composed schemas",
-        ));
+    if version == OasVersion::V3_0 {
+        collapse_nullable_any_of(&mut schema);
+        wrap_reference_with_siblings(&mut schema);
+        if mode == SchemaMode::Strict
+            && schema.get("nullable") == Some(&Value::Bool(true))
+            && !schema.contains_key("type")
+        {
+            return Err(unsupported(
+                component,
+                "nullable references or composed schemas",
+            ));
+        }
     }
     Ok(Value::Object(schema))
 }

--- a/specta-openapi/src/transform.rs
+++ b/specta-openapi/src/transform.rs
@@ -14,6 +14,8 @@ pub(crate) fn components(
     let mut schema = specta_jsonschema::JsonSchema::default()
         // OpenAPI generators map numeric formats to language types.
         .number_formats(true)
+        // Generators map string formats to language date/URL/UUID types.
+        .string_formats(true)
         .export_value(types, format)?;
     let definitions = schema
         .as_object_mut()

--- a/specta-openapi/src/transform.rs
+++ b/specta-openapi/src/transform.rs
@@ -11,7 +11,10 @@ pub(crate) fn components(
     format: impl Format,
     mode: SchemaMode,
 ) -> Result<Components, Error> {
-    let mut schema = specta_jsonschema::JsonSchema::default().export_value(types, format)?;
+    let mut schema = specta_jsonschema::JsonSchema::default()
+        // OpenAPI generators map numeric formats to language types.
+        .number_formats(true)
+        .export_value(types, format)?;
     let definitions = schema
         .as_object_mut()
         .and_then(|root| root.remove("$defs").or_else(|| root.remove("definitions")))
@@ -169,6 +172,8 @@ fn transform_object(
     if let Some(constant) = schema.remove("const") {
         schema.insert("enum".to_string(), Value::Array(vec![constant]));
     }
+
+    compact_string_enum(&mut schema);
 
     if schema.get("type").and_then(Value::as_str) == Some("null") {
         if mode == SchemaMode::Strict {
@@ -380,4 +385,55 @@ fn is_nullable_only(value: &Value) -> bool {
                     )
                 }))
     })
+}
+
+/// Collapses a `oneOf` whose members are all single-value string enums - the
+/// shape a plain string enum renders as - into the compact
+/// `{ "type": "string", "enum": [...] }` form generators handle best.
+/// Per-variant descriptions have no home in the compact form, so when any
+/// member carries one they are retained in `x-specta-enum-descriptions`,
+/// keyed by value.
+fn compact_string_enum(schema: &mut Map<String, Value>) {
+    let Some(Value::Array(members)) = schema.get("oneOf") else {
+        return;
+    };
+    let mut values = Vec::with_capacity(members.len());
+    let mut descriptions = Map::new();
+    for member in members {
+        let Value::Object(member) = member else {
+            return;
+        };
+        // Exactly a single string value - members are inspected before their
+        // own transform runs, so both the JSON Schema `const` form and the
+        // already-lowered single-value `enum` form appear here - with nothing
+        // but an optional description beside it.
+        let value = match (member.get("const"), member.get("enum")) {
+            (Some(Value::String(value)), None) => value,
+            (None, Some(Value::Array(constants))) => match constants.as_slice() {
+                [Value::String(value)] => value,
+                _ => return,
+            },
+            _ => return,
+        };
+        if member
+            .keys()
+            .any(|key| !matches!(key.as_str(), "const" | "enum" | "description"))
+        {
+            return;
+        }
+        if let Some(Value::String(description)) = member.get("description") {
+            // Doc comments arrive with their leading space.
+            descriptions.insert(value.clone(), Value::String(description.trim().to_string()));
+        }
+        values.push(Value::String(value.clone()));
+    }
+    schema.remove("oneOf");
+    schema.insert("type".to_string(), Value::String("string".into()));
+    schema.insert("enum".to_string(), Value::Array(values));
+    if !descriptions.is_empty() {
+        schema.insert(
+            "x-specta-enum-descriptions".to_string(),
+            Value::Object(descriptions),
+        );
+    }
 }

--- a/specta-openapi/src/transform.rs
+++ b/specta-openapi/src/transform.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeMap;
 
-use openapiv3::{Components, ReferenceOr, Schema};
 use serde_json::{Map, Value, json};
 use specta::{Format, Types};
 
@@ -10,7 +9,7 @@ pub(crate) fn components(
     types: &Types,
     format: impl Format,
     mode: SchemaMode,
-) -> Result<Components, Error> {
+) -> Result<BTreeMap<String, Value>, Error> {
     let mut schema = specta_jsonschema::JsonSchema::default()
         // OpenAPI generators map numeric formats to language types.
         .number_formats(true)
@@ -35,7 +34,7 @@ pub(crate) fn components(
         references.insert(definition_ref(name), component_name);
     }
 
-    let mut components = Components::default();
+    let mut components = BTreeMap::new();
     for (name, mut schema) in definitions {
         let component_name = references
             .get(&definition_ref(&name))
@@ -43,14 +42,7 @@ pub(crate) fn components(
             .unwrap_or_else(|| component_name(&name));
         rewrite_component_refs(&mut schema, &references);
         let schema = component_schema(transform(schema, &component_name, mode)?);
-        let schema =
-            serde_json::from_value::<Schema>(schema).map_err(|source| Error::InvalidSchema {
-                component: component_name.clone(),
-                source,
-            })?;
-        components
-            .schemas
-            .insert(component_name, ReferenceOr::Item(schema));
+        components.insert(component_name, schema);
     }
     Ok(components)
 }
@@ -186,9 +178,6 @@ fn transform_object(
         schema.insert("x-specta-type".to_string(), Value::String("null".into()));
     }
 
-    preserve_lossy_integer_bound(&mut schema, "minimum", component, mode)?;
-    preserve_lossy_integer_bound(&mut schema, "maximum", component, mode)?;
-
     // Collapse nullable unions before recursively transforming their branches.
     // Otherwise strict mode rejects the raw `{ "type": "null" }` branch before
     // it can be represented by OpenAPI 3.0's `nullable` keyword.
@@ -262,31 +251,6 @@ fn transform_object(
         ));
     }
     Ok(Value::Object(schema))
-}
-
-fn preserve_lossy_integer_bound(
-    schema: &mut Map<String, Value>,
-    keyword: &str,
-    component: &str,
-    mode: SchemaMode,
-) -> Result<(), Error> {
-    let Some(Value::Number(bound)) = schema.get(keyword) else {
-        return Ok(());
-    };
-    // `openapiv3` stores integer bounds as `i64`, so signed bounds remain
-    // exact. Larger unsigned bounds fall back to its floating-point schema
-    // representation and must not be silently rounded.
-    if bound.as_i64().is_some() || bound.as_u64().is_none() {
-        return Ok(());
-    }
-    if mode == SchemaMode::Strict {
-        return Err(unsupported(component, "exact 64-bit integer bounds"));
-    }
-
-    if let Some(bound) = schema.remove(keyword) {
-        schema.insert(format!("x-specta-{keyword}"), bound);
-    }
-    Ok(())
 }
 
 fn move_unsupported_keyword(

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -33,7 +33,6 @@ serde_json = "1.0.150"
 serde_yaml = "0.9.34"
 toml = "1.1.2"
 insta = "1.48.0"
-openapiv3 = { version = "2", default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 either = { version = "1.16", default-features = false }
 ulid = { version = "2.0", default-features = false, features = [] }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -11,7 +11,7 @@ path = "tests/mod.rs"
 harness = true
 
 [dependencies]
-specta = { path = "../specta", features = ["function", "std", "derive", "serde_json", "serde_yaml", "toml", "chrono", "either", "error-stack", "ulid", "glam", "ordered-float", "heapless", "semver", "smol_str", "arrayvec", "smallvec", "geojson", "bson", "uhlc"] }
+specta = { path = "../specta", features = ["function", "std", "derive", "serde_json", "serde_yaml", "toml", "chrono", "either", "error-stack", "ulid", "glam", "ordered-float", "heapless", "semver", "smol_str", "arrayvec", "smallvec", "geojson", "bson", "uhlc", "uuid", "url", "jiff"] }
 specta-go = { path = "../specta-go" }
 specta-jsonschema = { path = "../specta-jsonschema" }
 specta-java = { path = "../specta-java" }
@@ -34,6 +34,9 @@ serde_yaml = "0.9.34"
 toml = "1.1.2"
 insta = "1.48.0"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+uuid = { version = "1", default-features = false }
+url = { version = "2", default-features = false }
+jiff = { version = "0.2", default-features = false }
 either = { version = "1.16", default-features = false }
 ulid = { version = "2.0", default-features = false, features = [] }
 glam = { version = "0.33", default-features = false, features = ["std", "all-types"] }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -49,3 +49,6 @@ thiserror = "2.0.18"
 error-stack = { version = "0.8", default-features = false }
 bson = { version = "3", default-features = false, features = ["compat-3-0-0"] }
 uhlc = { version = "0.9", default-features = false }
+
+[dev-dependencies]
+jsonschema = { version = "0.48.1", default-features = false, features = ["resolve-file"] }

--- a/tests/schemas/openapi-3.0-2024-10-18.json
+++ b/tests/schemas/openapi-3.0-2024-10-18.json
@@ -1,0 +1,1651 @@
+{
+  "id": "https://spec.openapis.org/oas/3.0/schema/2024-10-18",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "The description of OpenAPI v3.0.x Documents",
+  "type": "object",
+  "required": [
+    "openapi",
+    "info",
+    "paths"
+  ],
+  "properties": {
+    "openapi": {
+      "type": "string",
+      "pattern": "^3\\.0\\.\\d(-.+)?$"
+    },
+    "info": {
+      "$ref": "#/definitions/Info"
+    },
+    "externalDocs": {
+      "$ref": "#/definitions/ExternalDocumentation"
+    },
+    "servers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Server"
+      }
+    },
+    "security": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/SecurityRequirement"
+      }
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Tag"
+      },
+      "uniqueItems": true
+    },
+    "paths": {
+      "$ref": "#/definitions/Paths"
+    },
+    "components": {
+      "$ref": "#/definitions/Components"
+    }
+  },
+  "patternProperties": {
+    "^x-": {}
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Reference": {
+      "type": "object",
+      "required": [
+        "$ref"
+      ],
+      "patternProperties": {
+        "^\\$ref$": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      }
+    },
+    "Info": {
+      "type": "object",
+      "required": [
+        "title",
+        "version"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "termsOfService": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "contact": {
+          "$ref": "#/definitions/Contact"
+        },
+        "license": {
+          "$ref": "#/definitions/License"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Contact": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "License": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Server": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "variables": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ServerVariable"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "ServerVariable": {
+      "type": "object",
+      "required": [
+        "default"
+      ],
+      "properties": {
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Components": {
+      "type": "object",
+      "properties": {
+        "schemas": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Schema"
+                },
+                {
+                  "$ref": "#/definitions/Reference"
+                }
+              ]
+            }
+          }
+        },
+        "responses": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Response"
+                }
+              ]
+            }
+          }
+        },
+        "parameters": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Parameter"
+                }
+              ]
+            }
+          }
+        },
+        "examples": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Example"
+                }
+              ]
+            }
+          }
+        },
+        "requestBodies": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/RequestBody"
+                }
+              ]
+            }
+          }
+        },
+        "headers": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Header"
+                }
+              ]
+            }
+          }
+        },
+        "securitySchemes": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/SecurityScheme"
+                }
+              ]
+            }
+          }
+        },
+        "links": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Link"
+                }
+              ]
+            }
+          }
+        },
+        "callbacks": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9\\.\\-_]+$": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Reference"
+                },
+                {
+                  "$ref": "#/definitions/Callback"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Schema": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "multipleOf": {
+          "type": "number",
+          "minimum": 0,
+          "exclusiveMinimum": true
+        },
+        "maximum": {
+          "type": "number"
+        },
+        "exclusiveMaximum": {
+          "type": "boolean",
+          "default": false
+        },
+        "minimum": {
+          "type": "number"
+        },
+        "exclusiveMinimum": {
+          "type": "boolean",
+          "default": false
+        },
+        "maxLength": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minLength": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        },
+        "pattern": {
+          "type": "string",
+          "format": "regex"
+        },
+        "maxItems": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minItems": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        },
+        "uniqueItems": {
+          "type": "boolean",
+          "default": false
+        },
+        "maxProperties": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minProperties": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        },
+        "required": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "enum": {
+          "type": "array",
+          "items": {},
+          "minItems": 1,
+          "uniqueItems": false
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "array",
+            "boolean",
+            "integer",
+            "number",
+            "object",
+            "string"
+          ]
+        },
+        "not": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "allOf": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Schema"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "oneOf": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Schema"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "anyOf": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Schema"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "items": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Schema"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "default": true
+        },
+        "description": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "default": {},
+        "nullable": {
+          "type": "boolean",
+          "default": false
+        },
+        "discriminator": {
+          "$ref": "#/definitions/Discriminator"
+        },
+        "readOnly": {
+          "type": "boolean",
+          "default": false
+        },
+        "writeOnly": {
+          "type": "boolean",
+          "default": false
+        },
+        "example": {},
+        "externalDocs": {
+          "$ref": "#/definitions/ExternalDocumentation"
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "xml": {
+          "$ref": "#/definitions/XML"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Discriminator": {
+      "type": "object",
+      "required": [
+        "propertyName"
+      ],
+      "properties": {
+        "propertyName": {
+          "type": "string"
+        },
+        "mapping": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "XML": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string",
+          "format": "uri"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "attribute": {
+          "type": "boolean",
+          "default": false
+        },
+        "wrapped": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Response": {
+      "type": "object",
+      "required": [
+        "description"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Header"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "content": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          }
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Link"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "MediaType": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "example": {},
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Example"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "encoding": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Encoding"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExampleXORExamples"
+        }
+      ]
+    },
+    "Example": {
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "value": {},
+        "externalValue": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Header": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean",
+          "default": false
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "allowEmptyValue": {
+          "type": "boolean",
+          "default": false
+        },
+        "style": {
+          "type": "string",
+          "enum": [
+            "simple"
+          ],
+          "default": "simple"
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "type": "boolean",
+          "default": false
+        },
+        "schema": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "content": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          },
+          "minProperties": 1,
+          "maxProperties": 1
+        },
+        "example": {},
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Example"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExampleXORExamples"
+        },
+        {
+          "$ref": "#/definitions/SchemaXORContent"
+        }
+      ]
+    },
+    "Paths": {
+      "type": "object",
+      "patternProperties": {
+        "^\\/": {
+          "$ref": "#/definitions/PathItem"
+        },
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "PathItem": {
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "get": {
+          "$ref": "#/definitions/Operation"
+        },
+        "put": {
+          "$ref": "#/definitions/Operation"
+        },
+        "post": {
+          "$ref": "#/definitions/Operation"
+        },
+        "delete": {
+          "$ref": "#/definitions/Operation"
+        },
+        "options": {
+          "$ref": "#/definitions/Operation"
+        },
+        "head": {
+          "$ref": "#/definitions/Operation"
+        },
+        "patch": {
+          "$ref": "#/definitions/Operation"
+        },
+        "trace": {
+          "$ref": "#/definitions/Operation"
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Server"
+          }
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Parameter"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          },
+          "uniqueItems": true
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Operation": {
+      "type": "object",
+      "required": [
+        "responses"
+      ],
+      "properties": {
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/ExternalDocumentation"
+        },
+        "operationId": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Parameter"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          },
+          "uniqueItems": true
+        },
+        "requestBody": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/RequestBody"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "responses": {
+          "$ref": "#/definitions/Responses"
+        },
+        "callbacks": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Callback"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "security": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SecurityRequirement"
+          }
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Server"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Responses": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Response"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        }
+      },
+      "patternProperties": {
+        "^[1-5](?:\\d{2}|XX)$": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Response"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "^x-": {}
+      },
+      "minProperties": 1,
+      "additionalProperties": false
+    },
+    "SecurityRequirement": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "Tag": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/ExternalDocumentation"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "ExternalDocumentation": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "ExampleXORExamples": {
+      "description": "Example and examples are mutually exclusive",
+      "not": {
+        "required": [
+          "example",
+          "examples"
+        ]
+      }
+    },
+    "SchemaXORContent": {
+      "description": "Schema and content are mutually exclusive, at least one is required",
+      "not": {
+        "required": [
+          "schema",
+          "content"
+        ]
+      },
+      "oneOf": [
+        {
+          "required": [
+            "schema"
+          ]
+        },
+        {
+          "required": [
+            "content"
+          ],
+          "description": "Some properties are not allowed if content is present",
+          "allOf": [
+            {
+              "not": {
+                "required": [
+                  "style"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "explode"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "allowReserved"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "example"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "examples"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "Parameter": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean",
+          "default": false
+        },
+        "deprecated": {
+          "type": "boolean",
+          "default": false
+        },
+        "allowEmptyValue": {
+          "type": "boolean",
+          "default": false
+        },
+        "style": {
+          "type": "string"
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "type": "boolean",
+          "default": false
+        },
+        "schema": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Schema"
+            },
+            {
+              "$ref": "#/definitions/Reference"
+            }
+          ]
+        },
+        "content": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          },
+          "minProperties": 1,
+          "maxProperties": 1
+        },
+        "example": {},
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Example"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "in"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExampleXORExamples"
+        },
+        {
+          "$ref": "#/definitions/SchemaXORContent"
+        }
+      ],
+      "oneOf": [
+        {
+          "$ref": "#/definitions/PathParameter"
+        },
+        {
+          "$ref": "#/definitions/QueryParameter"
+        },
+        {
+          "$ref": "#/definitions/HeaderParameter"
+        },
+        {
+          "$ref": "#/definitions/CookieParameter"
+        }
+      ]
+    },
+    "PathParameter": {
+      "description": "Parameter in path",
+      "required": [
+        "required"
+      ],
+      "properties": {
+        "in": {
+          "enum": [
+            "path"
+          ]
+        },
+        "style": {
+          "enum": [
+            "matrix",
+            "label",
+            "simple"
+          ],
+          "default": "simple"
+        },
+        "required": {
+          "enum": [
+            true
+          ]
+        }
+      }
+    },
+    "QueryParameter": {
+      "description": "Parameter in query",
+      "properties": {
+        "in": {
+          "enum": [
+            "query"
+          ]
+        },
+        "style": {
+          "enum": [
+            "form",
+            "spaceDelimited",
+            "pipeDelimited",
+            "deepObject"
+          ],
+          "default": "form"
+        }
+      }
+    },
+    "HeaderParameter": {
+      "description": "Parameter in header",
+      "properties": {
+        "in": {
+          "enum": [
+            "header"
+          ]
+        },
+        "style": {
+          "enum": [
+            "simple"
+          ],
+          "default": "simple"
+        }
+      }
+    },
+    "CookieParameter": {
+      "description": "Parameter in cookie",
+      "properties": {
+        "in": {
+          "enum": [
+            "cookie"
+          ]
+        },
+        "style": {
+          "enum": [
+            "form"
+          ],
+          "default": "form"
+        }
+      }
+    },
+    "RequestBody": {
+      "type": "object",
+      "required": [
+        "content"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "content": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          }
+        },
+        "required": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "SecurityScheme": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/APIKeySecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/HTTPSecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/OAuth2SecurityScheme"
+        },
+        {
+          "$ref": "#/definitions/OpenIdConnectSecurityScheme"
+        }
+      ]
+    },
+    "APIKeySecurityScheme": {
+      "type": "object",
+      "required": [
+        "type",
+        "name",
+        "in"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "apiKey"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "type": "string",
+          "enum": [
+            "header",
+            "query",
+            "cookie"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "HTTPSecurityScheme": {
+      "type": "object",
+      "required": [
+        "scheme",
+        "type"
+      ],
+      "properties": {
+        "scheme": {
+          "type": "string"
+        },
+        "bearerFormat": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "http"
+          ]
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false,
+      "oneOf": [
+        {
+          "description": "Bearer",
+          "properties": {
+            "scheme": {
+              "type": "string",
+              "pattern": "^[Bb][Ee][Aa][Rr][Ee][Rr]$"
+            }
+          }
+        },
+        {
+          "description": "Non Bearer",
+          "not": {
+            "required": [
+              "bearerFormat"
+            ]
+          },
+          "properties": {
+            "scheme": {
+              "not": {
+                "type": "string",
+                "pattern": "^[Bb][Ee][Aa][Rr][Ee][Rr]$"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "OAuth2SecurityScheme": {
+      "type": "object",
+      "required": [
+        "type",
+        "flows"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "oauth2"
+          ]
+        },
+        "flows": {
+          "$ref": "#/definitions/OAuthFlows"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "OpenIdConnectSecurityScheme": {
+      "type": "object",
+      "required": [
+        "type",
+        "openIdConnectUrl"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "openIdConnect"
+          ]
+        },
+        "openIdConnectUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "OAuthFlows": {
+      "type": "object",
+      "properties": {
+        "implicit": {
+          "$ref": "#/definitions/ImplicitOAuthFlow"
+        },
+        "password": {
+          "$ref": "#/definitions/PasswordOAuthFlow"
+        },
+        "clientCredentials": {
+          "$ref": "#/definitions/ClientCredentialsFlow"
+        },
+        "authorizationCode": {
+          "$ref": "#/definitions/AuthorizationCodeOAuthFlow"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "ImplicitOAuthFlow": {
+      "type": "object",
+      "required": [
+        "authorizationUrl",
+        "scopes"
+      ],
+      "properties": {
+        "authorizationUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "refreshUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "scopes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "PasswordOAuthFlow": {
+      "type": "object",
+      "required": [
+        "tokenUrl",
+        "scopes"
+      ],
+      "properties": {
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "refreshUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "scopes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "ClientCredentialsFlow": {
+      "type": "object",
+      "required": [
+        "tokenUrl",
+        "scopes"
+      ],
+      "properties": {
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "refreshUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "scopes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "AuthorizationCodeOAuthFlow": {
+      "type": "object",
+      "required": [
+        "authorizationUrl",
+        "tokenUrl",
+        "scopes"
+      ],
+      "properties": {
+        "authorizationUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "tokenUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "refreshUrl": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "scopes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    },
+    "Link": {
+      "type": "object",
+      "properties": {
+        "operationId": {
+          "type": "string"
+        },
+        "operationRef": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {}
+        },
+        "requestBody": {},
+        "description": {
+          "type": "string"
+        },
+        "server": {
+          "$ref": "#/definitions/Server"
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false,
+      "not": {
+        "description": "Operation Id and Operation Ref are mutually exclusive",
+        "required": [
+          "operationId",
+          "operationRef"
+        ]
+      }
+    },
+    "Callback": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/PathItem"
+      },
+      "patternProperties": {
+        "^x-": {}
+      }
+    },
+    "Encoding": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Header"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
+          }
+        },
+        "style": {
+          "type": "string",
+          "enum": [
+            "form",
+            "spaceDelimited",
+            "pipeDelimited",
+            "deepObject"
+          ]
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "patternProperties": {
+        "^x-": {}
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/tests/schemas/openapi-3.1-2025-11-23.json
+++ b/tests/schemas/openapi-3.1-2025-11-23.json
@@ -1,0 +1,1412 @@
+{
+  "$id": "https://spec.openapis.org/oas/3.1/schema/2025-11-23",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The description of OpenAPI v3.1.x Documents without Schema Object validation",
+  "type": "object",
+  "properties": {
+    "openapi": {
+      "type": "string",
+      "pattern": "^3\\.1\\.\\d+(-.+)?$"
+    },
+    "info": {
+      "$ref": "#/$defs/info"
+    },
+    "jsonSchemaDialect": {
+      "type": "string",
+      "format": "uri-reference",
+      "default": "https://spec.openapis.org/oas/3.1/dialect/2024-11-10"
+    },
+    "servers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/server"
+      },
+      "default": [
+        {
+          "url": "/"
+        }
+      ]
+    },
+    "paths": {
+      "$ref": "#/$defs/paths"
+    },
+    "webhooks": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/path-item"
+      }
+    },
+    "components": {
+      "$ref": "#/$defs/components"
+    },
+    "security": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/security-requirement"
+      }
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/tag"
+      }
+    },
+    "externalDocs": {
+      "$ref": "#/$defs/external-documentation"
+    }
+  },
+  "required": [
+    "openapi",
+    "info"
+  ],
+  "anyOf": [
+    {
+      "required": [
+        "paths"
+      ]
+    },
+    {
+      "required": [
+        "components"
+      ]
+    },
+    {
+      "required": [
+        "webhooks"
+      ]
+    }
+  ],
+  "$ref": "#/$defs/specification-extensions",
+  "unevaluatedProperties": false,
+  "$defs": {
+    "info": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#info-object",
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "termsOfService": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "contact": {
+          "$ref": "#/$defs/contact"
+        },
+        "license": {
+          "$ref": "#/$defs/license"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "title",
+        "version"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "contact": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#contact-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "license": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#license-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "identifier": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "dependentSchemas": {
+        "identifier": {
+          "not": {
+            "required": [
+              "url"
+            ]
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "server": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#server-object",
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "variables": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/server-variable"
+          }
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "server-variable": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#server-variable-object",
+      "type": "object",
+      "properties": {
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "default"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "components": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#components-object",
+      "type": "object",
+      "properties": {
+        "schemas": {
+          "type": "object",
+          "additionalProperties": {
+            "$dynamicRef": "#meta"
+          }
+        },
+        "responses": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/response-or-reference"
+          }
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/parameter-or-reference"
+          }
+        },
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/example-or-reference"
+          }
+        },
+        "requestBodies": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/request-body-or-reference"
+          }
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/header-or-reference"
+          }
+        },
+        "securitySchemes": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/security-scheme-or-reference"
+          }
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/link-or-reference"
+          }
+        },
+        "callbacks": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/callbacks-or-reference"
+          }
+        },
+        "pathItems": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/path-item"
+          }
+        }
+      },
+      "patternProperties": {
+        "^(?:schemas|responses|parameters|examples|requestBodies|headers|securitySchemes|links|callbacks|pathItems)$": {
+          "$comment": "Enumerating all of the property names in the regex above is necessary for unevaluatedProperties to work as expected",
+          "propertyNames": {
+            "pattern": "^[a-zA-Z0-9._-]+$"
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "paths": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#paths-object",
+      "type": "object",
+      "patternProperties": {
+        "^/": {
+          "$ref": "#/$defs/path-item"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "path-item": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#path-item-object",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/server"
+          }
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/parameter-or-reference"
+          }
+        },
+        "get": {
+          "$ref": "#/$defs/operation"
+        },
+        "put": {
+          "$ref": "#/$defs/operation"
+        },
+        "post": {
+          "$ref": "#/$defs/operation"
+        },
+        "delete": {
+          "$ref": "#/$defs/operation"
+        },
+        "options": {
+          "$ref": "#/$defs/operation"
+        },
+        "head": {
+          "$ref": "#/$defs/operation"
+        },
+        "patch": {
+          "$ref": "#/$defs/operation"
+        },
+        "trace": {
+          "$ref": "#/$defs/operation"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "operation": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#operation-object",
+      "type": "object",
+      "properties": {
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/$defs/external-documentation"
+        },
+        "operationId": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/parameter-or-reference"
+          }
+        },
+        "requestBody": {
+          "$ref": "#/$defs/request-body-or-reference"
+        },
+        "responses": {
+          "$ref": "#/$defs/responses"
+        },
+        "callbacks": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/callbacks-or-reference"
+          }
+        },
+        "deprecated": {
+          "default": false,
+          "type": "boolean"
+        },
+        "security": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/security-requirement"
+          }
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/server"
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "external-documentation": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#external-documentation-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "parameter": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#parameter-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "enum": [
+            "query",
+            "header",
+            "path",
+            "cookie"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "default": false,
+          "type": "boolean"
+        },
+        "deprecated": {
+          "default": false,
+          "type": "boolean"
+        },
+        "schema": {
+          "$dynamicRef": "#meta"
+        },
+        "content": {
+          "$ref": "#/$defs/content",
+          "minProperties": 1,
+          "maxProperties": 1
+        }
+      },
+      "required": [
+        "name",
+        "in"
+      ],
+      "oneOf": [
+        {
+          "required": [
+            "schema"
+          ]
+        },
+        {
+          "required": [
+            "content"
+          ]
+        }
+      ],
+      "if": {
+        "properties": {
+          "in": {
+            "const": "query"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "allowEmptyValue": {
+            "default": false,
+            "type": "boolean"
+          }
+        }
+      },
+      "dependentSchemas": {
+        "schema": {
+          "properties": {
+            "style": {
+              "type": "string"
+            },
+            "explode": {
+              "type": "boolean"
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/$defs/examples"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-path"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-header"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-query"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-cookie"
+            }
+          ],
+          "$defs": {
+            "styles-for-path": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "path"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "name": {
+                    "pattern": "^[^{}]+$"
+                  },
+                  "style": {
+                    "default": "simple",
+                    "enum": [
+                      "matrix",
+                      "label",
+                      "simple"
+                    ]
+                  },
+                  "required": {
+                    "const": true
+                  },
+                  "explode": {
+                    "default": false
+                  }
+                },
+                "required": [
+                  "required"
+                ]
+              }
+            },
+            "styles-for-header": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "header"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "style": {
+                    "default": "simple",
+                    "const": "simple"
+                  },
+                  "explode": {
+                    "default": false
+                  }
+                }
+              }
+            },
+            "styles-for-query": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "query"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "style": {
+                    "default": "form",
+                    "enum": [
+                      "form",
+                      "spaceDelimited",
+                      "pipeDelimited",
+                      "deepObject"
+                    ]
+                  },
+                  "allowReserved": {
+                    "default": false,
+                    "type": "boolean"
+                  }
+                },
+                "$ref": "#/$defs/explode-for-form"
+              }
+            },
+            "styles-for-cookie": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "cookie"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "style": {
+                    "default": "form",
+                    "const": "form"
+                  }
+                },
+                "$ref": "#/$defs/explode-for-form"
+              }
+            }
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "parameter-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/parameter"
+      }
+    },
+    "request-body": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#request-body-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "content": {
+          "$ref": "#/$defs/content"
+        },
+        "required": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "content"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "request-body-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/request-body"
+      }
+    },
+    "content": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#fixed-fields-10",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/media-type"
+      },
+      "propertyNames": {
+        "format": "media-range"
+      }
+    },
+    "media-type": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#media-type-object",
+      "type": "object",
+      "properties": {
+        "schema": {
+          "$dynamicRef": "#meta"
+        },
+        "encoding": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/encoding"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/$defs/specification-extensions"
+        },
+        {
+          "$ref": "#/$defs/examples"
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "encoding": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#encoding-object",
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string",
+          "format": "media-range"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/header-or-reference"
+          }
+        },
+        "style": {
+          "enum": [
+            "form",
+            "spaceDelimited",
+            "pipeDelimited",
+            "deepObject"
+          ]
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "type": "boolean"
+        }
+      },
+      "dependentSchemas": {
+        "style": {
+          "properties": {
+            "allowReserved": {
+              "default": false
+            }
+          },
+          "$ref": "#/$defs/explode-for-form"
+        },
+        "explode": {
+          "properties": {
+            "style": {
+              "default": "form"
+            },
+            "allowReserved": {
+              "default": false
+            }
+          }
+        },
+        "allowReserved": {
+          "properties": {
+            "style": {
+              "default": "form"
+            }
+          },
+          "$ref": "#/$defs/explode-for-form"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "responses": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#responses-object",
+      "type": "object",
+      "properties": {
+        "default": {
+          "$ref": "#/$defs/response-or-reference"
+        }
+      },
+      "patternProperties": {
+        "^[1-5](?:[0-9]{2}|XX)$": {
+          "$ref": "#/$defs/response-or-reference"
+        }
+      },
+      "minProperties": 1,
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false,
+      "if": {
+        "$comment": "either default, or at least one response code property must exist",
+        "patternProperties": {
+          "^[1-5](?:[0-9]{2}|XX)$": false
+        }
+      },
+      "then": {
+        "required": [
+          "default"
+        ]
+      }
+    },
+    "response": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#response-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/header-or-reference"
+          }
+        },
+        "content": {
+          "$ref": "#/$defs/content"
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/link-or-reference"
+          }
+        }
+      },
+      "required": [
+        "description"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "response-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/response"
+      }
+    },
+    "callbacks": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#callback-object",
+      "type": "object",
+      "$ref": "#/$defs/specification-extensions",
+      "additionalProperties": {
+        "$ref": "#/$defs/path-item"
+      }
+    },
+    "callbacks-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/callbacks"
+      }
+    },
+    "example": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#example-object",
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "value": true,
+        "externalValue": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "not": {
+        "required": [
+          "value",
+          "externalValue"
+        ]
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "example-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/example"
+      }
+    },
+    "link": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#link-object",
+      "type": "object",
+      "properties": {
+        "operationRef": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "operationId": {
+          "type": "string"
+        },
+        "parameters": {
+          "$ref": "#/$defs/map-of-strings"
+        },
+        "requestBody": true,
+        "description": {
+          "type": "string"
+        },
+        "server": {
+          "$ref": "#/$defs/server"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "operationRef"
+          ]
+        },
+        {
+          "required": [
+            "operationId"
+          ]
+        }
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "link-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/link"
+      }
+    },
+    "header": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#header-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "default": false,
+          "type": "boolean"
+        },
+        "deprecated": {
+          "default": false,
+          "type": "boolean"
+        },
+        "schema": {
+          "$dynamicRef": "#meta"
+        },
+        "content": {
+          "$ref": "#/$defs/content",
+          "minProperties": 1,
+          "maxProperties": 1
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "schema"
+          ]
+        },
+        {
+          "required": [
+            "content"
+          ]
+        }
+      ],
+      "dependentSchemas": {
+        "schema": {
+          "properties": {
+            "style": {
+              "default": "simple",
+              "const": "simple"
+            },
+            "explode": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          "$ref": "#/$defs/examples"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "header-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/header"
+      }
+    },
+    "tag": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#tag-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/$defs/external-documentation"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "reference": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#reference-object",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "schema": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#schema-object",
+      "$dynamicAnchor": "meta",
+      "type": [
+        "object",
+        "boolean"
+      ]
+    },
+    "security-scheme": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#security-scheme-object",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "apiKey",
+            "http",
+            "mutualTLS",
+            "oauth2",
+            "openIdConnect"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/$defs/specification-extensions"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-apikey"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-http"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-http-bearer"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-oauth2"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-oidc"
+        }
+      ],
+      "unevaluatedProperties": false,
+      "$defs": {
+        "type-apikey": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "apiKey"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "in": {
+                "enum": [
+                  "query",
+                  "header",
+                  "cookie"
+                ]
+              }
+            },
+            "required": [
+              "name",
+              "in"
+            ]
+          }
+        },
+        "type-http": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "http"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "scheme": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "scheme"
+            ]
+          }
+        },
+        "type-http-bearer": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "http"
+              },
+              "scheme": {
+                "type": "string",
+                "pattern": "^[Bb][Ee][Aa][Rr][Ee][Rr]$"
+              }
+            },
+            "required": [
+              "type",
+              "scheme"
+            ]
+          },
+          "then": {
+            "properties": {
+              "bearerFormat": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "type-oauth2": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "oauth2"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "flows": {
+                "$ref": "#/$defs/oauth-flows"
+              }
+            },
+            "required": [
+              "flows"
+            ]
+          }
+        },
+        "type-oidc": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "openIdConnect"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "openIdConnectUrl": {
+                "type": "string",
+                "format": "uri-reference"
+              }
+            },
+            "required": [
+              "openIdConnectUrl"
+            ]
+          }
+        }
+      }
+    },
+    "security-scheme-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/security-scheme"
+      }
+    },
+    "oauth-flows": {
+      "type": "object",
+      "properties": {
+        "implicit": {
+          "$ref": "#/$defs/oauth-flows/$defs/implicit"
+        },
+        "password": {
+          "$ref": "#/$defs/oauth-flows/$defs/password"
+        },
+        "clientCredentials": {
+          "$ref": "#/$defs/oauth-flows/$defs/client-credentials"
+        },
+        "authorizationCode": {
+          "$ref": "#/$defs/oauth-flows/$defs/authorization-code"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false,
+      "$defs": {
+        "implicit": {
+          "type": "object",
+          "properties": {
+            "authorizationUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "authorizationUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        },
+        "password": {
+          "type": "object",
+          "properties": {
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "tokenUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        },
+        "client-credentials": {
+          "type": "object",
+          "properties": {
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "tokenUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        },
+        "authorization-code": {
+          "type": "object",
+          "properties": {
+            "authorizationUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "authorizationUrl",
+            "tokenUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        }
+      }
+    },
+    "security-requirement": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#security-requirement-object",
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "specification-extensions": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#specification-extensions",
+      "patternProperties": {
+        "^x-": true
+      }
+    },
+    "examples": {
+      "properties": {
+        "example": true,
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/example-or-reference"
+          }
+        }
+      },
+      "not": {
+        "required": [
+          "example",
+          "examples"
+        ]
+      }
+    },
+    "map-of-strings": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "explode-for-form": {
+      "$comment": "for encoding objects, and query and cookie parameters, style=form is the default",
+      "if": {
+        "properties": {
+          "style": {
+            "const": "form"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "explode": {
+            "default": true
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "explode": {
+            "default": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/schemas/openapi-3.1-dialect-2024-11-10.json
+++ b/tests/schemas/openapi-3.1-dialect-2024-11-10.json
@@ -1,0 +1,25 @@
+{
+  "$id": "https://spec.openapis.org/oas/3.1/dialect/2024-11-10",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "OpenAPI 3.1 Schema Object Dialect",
+  "description": "A JSON Schema dialect describing schemas found in OpenAPI v3.1 Descriptions",
+  "$dynamicAnchor": "meta",
+  "$vocabulary": {
+    "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+    "https://json-schema.org/draft/2020-12/vocab/content": true,
+    "https://json-schema.org/draft/2020-12/vocab/core": true,
+    "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
+    "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
+    "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
+    "https://json-schema.org/draft/2020-12/vocab/validation": true,
+    "https://spec.openapis.org/oas/3.1/vocab/base": false
+  },
+  "allOf": [
+    {
+      "$ref": "https://json-schema.org/draft/2020-12/schema"
+    },
+    {
+      "$ref": "https://spec.openapis.org/oas/3.1/meta/2024-11-10"
+    }
+  ]
+}

--- a/tests/schemas/openapi-3.1-meta-2024-11-10.json
+++ b/tests/schemas/openapi-3.1-meta-2024-11-10.json
@@ -1,0 +1,92 @@
+{
+  "$id": "https://spec.openapis.org/oas/3.1/meta/2024-11-10",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "OAS Base Vocabulary",
+  "description": "A JSON Schema Vocabulary used in the OpenAPI Schema Dialect",
+  "$dynamicAnchor": "meta",
+  "$vocabulary": {
+    "https://spec.openapis.org/oas/3.1/vocab/base": true
+  },
+  "type": [
+    "object",
+    "boolean"
+  ],
+  "properties": {
+    "discriminator": {
+      "$ref": "#/$defs/discriminator"
+    },
+    "example": true,
+    "externalDocs": {
+      "$ref": "#/$defs/external-docs"
+    },
+    "xml": {
+      "$ref": "#/$defs/xml"
+    }
+  },
+  "$defs": {
+    "discriminator": {
+      "$ref": "#/$defs/extensible",
+      "properties": {
+        "mapping": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "propertyName": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "propertyName"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "extensible": {
+      "patternProperties": {
+        "^x-": true
+      }
+    },
+    "external-docs": {
+      "$ref": "#/$defs/extensible",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "format": "uri-reference",
+          "type": "string"
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "xml": {
+      "$ref": "#/$defs/extensible",
+      "properties": {
+        "attribute": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "format": "uri",
+          "type": "string"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "wrapped": {
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "unevaluatedProperties": false
+    }
+  }
+}

--- a/tests/schemas/openapi-3.1-schema-base-2025-11-23.json
+++ b/tests/schemas/openapi-3.1-schema-base-2025-11-23.json
@@ -1,0 +1,25 @@
+{
+  "$id": "https://spec.openapis.org/oas/3.1/schema-base/2025-11-23",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The description of OpenAPI v3.1.x Documents using the OpenAPI JSON Schema dialect",
+  "$ref": "https://spec.openapis.org/oas/3.1/schema/2025-11-23",
+  "properties": {
+    "jsonSchemaDialect": {
+      "$ref": "#/$defs/dialect"
+    }
+  },
+  "$defs": {
+    "dialect": {
+      "const": "https://spec.openapis.org/oas/3.1/dialect/2024-11-10"
+    },
+    "schema": {
+      "$dynamicAnchor": "meta",
+      "$ref": "https://spec.openapis.org/oas/3.1/dialect/2024-11-10",
+      "properties": {
+        "$schema": {
+          "$ref": "#/$defs/dialect"
+        }
+      }
+    }
+  }
+}

--- a/tests/tests/jsonschema.rs
+++ b/tests/tests/jsonschema.rs
@@ -103,3 +103,34 @@ fn jsonschema_skip_slot_tuple_phases() {
     );
     insta::assert_snapshot!("jsonschema-skip-slot-tuple-phases", rendered);
 }
+
+/// String formats are opt-in: plain JSON Schema output is unchanged unless
+/// the knob is set.
+#[test]
+fn jsonschema_string_formats_are_opt_in() {
+    #[derive(specta::Type)]
+    #[specta(collect = false)]
+    struct Stamped {
+        at: chrono::DateTime<chrono::Utc>,
+    }
+
+    let types = specta::Types::default().register::<Stamped>();
+    let plain = specta_jsonschema::JsonSchema::default()
+        .export_value(&types, specta_serde::Format)
+        .expect("plain export");
+    assert!(
+        plain["$defs"]["Stamped"]["properties"]["at"]
+            .get("format")
+            .is_none(),
+        "formats must not appear unless enabled"
+    );
+
+    let formatted = specta_jsonschema::JsonSchema::default()
+        .string_formats(true)
+        .export_value(&types, specta_serde::Format)
+        .expect("formatted export");
+    assert_eq!(
+        formatted["$defs"]["Stamped"]["properties"]["at"]["format"],
+        "date-time"
+    );
+}

--- a/tests/tests/openapi.rs
+++ b/tests/tests/openapi.rs
@@ -849,3 +849,150 @@ fn openapi_types_parameters_from_their_extracted_type() {
     assert_eq!(parameters[1]["in"], "query");
     assert_eq!(parameters[1]["schema"]["type"], "string");
 }
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+#[serde(rename_all = "snake_case")]
+enum PlainStringEnum {
+    /// Automatic per-location blend.
+    Auto,
+    Gfs,
+    Ecmwf,
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+struct NumericFormats {
+    small: u16,
+    lead: u32,
+    wide: i64,
+    ratio: f32,
+    value: f64,
+}
+
+#[derive(Type, Serialize, Deserialize)]
+#[specta(collect = false)]
+struct ProblemBody {
+    title: String,
+}
+
+/// Numeric schemas carry OpenAPI formats, and plain string enums render in
+/// the compact `type: string, enum: [...]` form with variant docs retained in
+/// an extension.
+#[test]
+fn numeric_formats_and_compact_string_enums() {
+    let types = Types::default()
+        .register::<NumericFormats>()
+        .register::<PlainStringEnum>();
+    let document = OpenApi::default()
+        .export_document(&types, specta_serde::Format)
+        .unwrap();
+    let json = serde_json::to_value(&document).unwrap();
+    let schemas = &json["components"]["schemas"];
+
+    let numeric = &schemas["NumericFormats"]["properties"];
+    assert_eq!(numeric["small"]["format"], "int32");
+    assert_eq!(numeric["lead"]["format"], "int64");
+    assert_eq!(numeric["wide"]["format"], "int64");
+    assert_eq!(numeric["ratio"]["format"], "float");
+    assert_eq!(numeric["value"]["format"], "double");
+
+    let string_enum = &schemas["PlainStringEnum"];
+    assert_eq!(string_enum["type"], "string");
+    assert_eq!(
+        string_enum["enum"],
+        serde_json::json!(["auto", "gfs", "ecmwf"])
+    );
+    assert!(string_enum.get("oneOf").is_none());
+    assert_eq!(
+        string_enum["x-specta-enum-descriptions"]["auto"],
+        "Automatic per-location blend."
+    );
+}
+
+/// The `Param` builder covers what the bare conveniences cannot: required
+/// query parameters, descriptions, and example values.
+#[test]
+fn parameters_carry_required_description_and_example() {
+    use specta_openapi::Param;
+
+    let types = Types::default().register::<ProblemBody>();
+    let document = OpenApi::default()
+        .operation(
+            Operation::get("/v1/weather/forecast")
+                .parameter(
+                    Param::query::<f64>("lat")
+                        .required()
+                        .description("Latitude, WGS84 degrees, -90 to 90")
+                        .example(serde_json::json!(35.0)),
+                )
+                .query_param::<u32>("horizon_hours")
+                .response::<ProblemBody>(200, "ok"),
+        )
+        .export_document(&types, specta_serde::Format)
+        .unwrap();
+    let json = serde_json::to_value(&document).unwrap();
+    let parameters = &json["paths"]["/v1/weather/forecast"]["get"]["parameters"];
+
+    assert_eq!(parameters[0]["name"], "lat");
+    assert_eq!(parameters[0]["required"], true);
+    assert_eq!(
+        parameters[0]["description"],
+        "Latitude, WGS84 degrees, -90 to 90"
+    );
+    assert_eq!(parameters[0]["example"], 35.0);
+    assert_eq!(parameters[0]["schema"]["format"], "double");
+
+    // The bare convenience stays optional (openapiv3 omits `required: false`)
+    // with no annotations.
+    assert_eq!(parameters[1]["name"], "horizon_hours");
+    assert_ne!(parameters[1]["required"], serde_json::json!(true));
+    assert!(parameters[1].get("example").is_none());
+}
+
+/// Error responses can be served as `application/problem+json`, security
+/// schemes register on the document, and operations state their security
+/// alternatives, the anonymous option included.
+#[test]
+fn content_types_security_and_document_metadata() {
+    let types = Types::default().register::<ProblemBody>();
+    let document = OpenApi::default()
+        .title("Orrery API")
+        .version("1.0.0")
+        .server_described("https://api.orr.sh", "Production")
+        .contact("Orrery", "https://orreryhq.com")
+        .tag("weather", "Weather intelligence")
+        .bearer_security_scheme("api_key", "opaque")
+        .operation(
+            Operation::get("/v1/me")
+                .tag("weather")
+                .response::<ProblemBody>(200, "ok")
+                .response_as::<ProblemBody>(
+                    401,
+                    "Missing or unknown key",
+                    "application/problem+json",
+                )
+                .security([("api_key", Vec::new())])
+                .security_optional(),
+        )
+        .export_document(&types, specta_serde::Format)
+        .unwrap();
+    let json = serde_json::to_value(&document).unwrap();
+
+    assert_eq!(json["servers"][0]["url"], "https://api.orr.sh");
+    assert_eq!(json["servers"][0]["description"], "Production");
+    assert_eq!(json["info"]["contact"]["name"], "Orrery");
+    assert_eq!(json["tags"][0]["description"], "Weather intelligence");
+    assert_eq!(
+        json["components"]["securitySchemes"]["api_key"]["scheme"],
+        "bearer"
+    );
+
+    let operation = &json["paths"]["/v1/me"]["get"];
+    assert!(operation["responses"]["200"]["content"]["application/json"].is_object());
+    assert!(operation["responses"]["401"]["content"]["application/problem+json"].is_object());
+    assert_eq!(
+        operation["security"],
+        serde_json::json!([{ "api_key": [] }, {}])
+    );
+}

--- a/tests/tests/openapi.rs
+++ b/tests/tests/openapi.rs
@@ -153,14 +153,13 @@ fn openapi_exports_full_type_corpus() {
         .export(&types, specta_serde::Format)
         .expect("the shared type corpus should be representable in OpenAPI");
 
-    let document: openapiv3::OpenAPI =
-        serde_json::from_str(&output).expect("output should be a valid typed OpenAPI document");
-    assert_eq!(document.openapi, "3.0.3");
+    let document: serde_json::Value =
+        serde_json::from_str(&output).expect("output should be a valid OpenAPI document");
+    assert_eq!(document["openapi"], "3.0.3");
     assert!(
-        document
-            .components
+        document["components"]["schemas"]
+            .as_object()
             .expect("components should exist")
-            .schemas
             .len()
             > 20
     );
@@ -176,12 +175,11 @@ fn openapi_exports_serde_phases() {
         .schema_mode(SchemaMode::Compatible)
         .export(&types, specta_serde::PhasesFormat)
         .expect("serialize and deserialize phase types should be representable in OpenAPI");
-    let document: openapiv3::OpenAPI =
+    let document: serde_json::Value =
         serde_json::from_str(&output).expect("phase output should be valid OpenAPI");
-    let schemas = &document
-        .components
-        .expect("components should exist")
-        .schemas;
+    let schemas = document["components"]["schemas"]
+        .as_object()
+        .expect("components should exist");
     assert!(schemas.keys().any(|name| name.contains("Serialize")));
     assert!(schemas.keys().any(|name| name.contains("Deserialize")));
 }
@@ -198,7 +196,7 @@ fn openapi_preserves_shapes_metadata_and_generics() {
         .schema_mode(SchemaMode::Compatible)
         .export_document(&types, specta_serde::Format)
         .expect("representative shapes should export");
-    let value = serde_json::to_value(document).expect("document should serialize");
+    let value = document;
     let schemas = &value["components"]["schemas"];
 
     assert_eq!(
@@ -261,7 +259,7 @@ fn openapi_materializes_directly_registered_generic_root() {
             specta_serde::Format,
         )
         .expect("a directly registered concrete generic should export");
-    let value = serde_json::to_value(document).unwrap();
+    let value = document;
 
     assert_eq!(
         value["components"]["schemas"]["RootWrapper_String"]["properties"]["value"]["type"],
@@ -278,7 +276,6 @@ fn openapi_strict_mode_rejects_lossy_openapi_3_shapes() {
             specta_serde::Format,
         )
         .expect("strict mode should represent nullable primitive fields exactly");
-    let optional = serde_json::to_value(optional).unwrap();
     assert_eq!(
         optional["components"]["schemas"]["StrictOptionalPrimitive"]["properties"]["value"]["type"],
         "string"
@@ -302,7 +299,6 @@ fn openapi_strict_mode_rejects_lossy_openapi_3_shapes() {
             specta_serde::Format,
         )
         .expect("strict mode should represent homogeneous fixed tuples exactly");
-    let homogeneous = serde_json::to_value(homogeneous).unwrap();
     let homogeneous = &homogeneous["components"]["schemas"]["StrictHomogeneousTuple"];
     assert_eq!(homogeneous["items"]["type"], "integer");
     assert_eq!(homogeneous["minItems"], 2);
@@ -341,9 +337,8 @@ fn openapi_strict_mode_rejects_lossy_openapi_3_shapes() {
             specta_serde::Format,
         )
         .expect("compatible mode should preserve tuple detail in an extension");
-    let value = serde_json::to_value(compatible).unwrap();
     assert_eq!(
-        value["components"]["schemas"]["StrictTuple"]["x-specta-prefix-items"]
+        compatible["components"]["schemas"]["StrictTuple"]["x-specta-prefix-items"]
             .as_array()
             .map(Vec::len),
         Some(2)
@@ -365,7 +360,6 @@ fn openapi_strict_mode_rejects_lossy_openapi_3_shapes() {
             specta_serde::Format,
         )
         .expect("compatible mode should preserve enum-key constraints");
-    let enum_map = serde_json::to_value(enum_map).unwrap();
     assert_eq!(
         enum_map["components"]["schemas"]["EnumMap"]["x-specta-property-names"]["$ref"],
         "#/components/schemas/EnumKey"
@@ -386,7 +380,6 @@ fn openapi_strict_mode_rejects_lossy_openapi_3_shapes() {
             specta_serde::Format,
         )
         .expect("compatible mode should emit a legal nullable approximation");
-    let compatible_unit = serde_json::to_value(compatible_unit).unwrap();
     let compatible_unit = &compatible_unit["components"]["schemas"]["StrictUnit"];
     assert_eq!(compatible_unit["type"], "object");
     assert_eq!(compatible_unit["nullable"], true);
@@ -400,7 +393,6 @@ fn openapi_strict_mode_rejects_lossy_openapi_3_shapes() {
             specta_serde::Format,
         )
         .expect("mergeable flattened objects are represented exactly");
-    let flattened = serde_json::to_value(flattened).unwrap();
     let flattened = &flattened["components"]["schemas"]["StrictFlattened"];
     assert_eq!(flattened["additionalProperties"], false);
     assert!(flattened["properties"].get("a").is_some());
@@ -426,7 +418,6 @@ fn openapi_strict_mode_rejects_lossy_openapi_3_shapes() {
             specta_serde::Format,
         )
         .expect("compatible mode should approximate a nullable reference");
-    let compatible_reference = serde_json::to_value(compatible_reference).unwrap();
     assert!(
         compatible_reference["components"]["schemas"]["StrictOptionalReference"]["properties"]
             ["value"]
@@ -443,28 +434,25 @@ fn openapi_strict_mode_rejects_lossy_openapi_3_shapes() {
     }
 }
 
+/// Schema bounds are plain JSON numbers, so 64-bit integer bounds are stated
+/// exactly in either schema mode — the spec has no integer-width limit.
 #[test]
-fn openapi_preserves_exact_wide_integer_bounds_in_extensions() {
+fn openapi_emits_exact_wide_integer_bounds() {
     let types = Types::default().register::<WideIntegers>();
-    let error = OpenApi::default()
-        .schema_mode(SchemaMode::Strict)
-        .export_document(&types, specta_serde::Format)
-        .expect_err("OpenAPI 3.0 cannot represent every 64-bit integer bound exactly");
-    assert!(error.to_string().contains("exact 64-bit integer bounds"));
+    for mode in [SchemaMode::Strict, SchemaMode::Compatible] {
+        let document = OpenApi::default()
+            .schema_mode(mode)
+            .export_document(&types, specta_serde::Format)
+            .expect("64-bit integer bounds are exactly representable");
+        let properties = &document["components"]["schemas"]["WideIntegers"]["properties"];
 
-    let document = OpenApi::default()
-        .schema_mode(SchemaMode::Compatible)
-        .export_document(&types, specta_serde::Format)
-        .expect("compatible mode should retain exact bounds in extensions");
-    let document = serde_json::to_value(document).unwrap();
-    let properties = &document["components"]["schemas"]["WideIntegers"]["properties"];
-
-    assert_eq!(properties["signed"]["maximum"], i64::MAX);
-    assert_eq!(properties["signed"]["minimum"], i64::MIN);
-    assert!(properties["signed"].get("x-specta-maximum").is_none());
-    assert!(properties["unsigned"].get("maximum").is_none());
-    assert_eq!(properties["unsigned"]["x-specta-maximum"], u64::MAX);
-    assert_eq!(properties["unsigned"]["minimum"], 0.0);
+        assert_eq!(properties["signed"]["maximum"], i64::MAX);
+        assert_eq!(properties["signed"]["minimum"], i64::MIN);
+        assert!(properties["signed"].get("x-specta-maximum").is_none());
+        assert_eq!(properties["unsigned"]["maximum"], u64::MAX);
+        assert!(properties["unsigned"].get("x-specta-maximum").is_none());
+        assert_eq!(properties["unsigned"]["minimum"], 0.0);
+    }
 }
 
 #[test]
@@ -518,9 +506,9 @@ fn openapi_supports_yaml_export_to_and_document_merging() {
     let yaml = exporter
         .export(&types, specta_serde::Format)
         .expect("YAML export should succeed");
-    let parsed: openapiv3::OpenAPI =
+    let parsed: serde_json::Value =
         serde_yaml::from_str(&yaml).expect("YAML should be a valid OpenAPI document");
-    assert_eq!(parsed.openapi, "3.0.3");
+    assert_eq!(parsed["openapi"], "3.0.3");
 
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("target")
@@ -532,7 +520,7 @@ fn openapi_supports_yaml_export_to_and_document_merging() {
     assert_eq!(std::fs::read_to_string(&path).unwrap(), yaml);
     std::fs::remove_file(path).unwrap();
 
-    let mut document = openapiv3::OpenAPI::default();
+    let mut document = serde_json::json!({});
     exporter
         .add_to_document(&mut document, &types, specta_serde::Format)
         .expect("components should merge into an empty document");
@@ -607,7 +595,7 @@ fn openapi_exports_operations_into_paths() {
         )
         .export_document(&recipe_types(), specta_serde::Format)
         .expect("operations should export");
-    let value = serde_json::to_value(&document).unwrap();
+    let value = document;
 
     let get = &value["paths"]["/recipes/{slug}"]["get"];
     assert_eq!(get["summary"], "Fetch one recipe");
@@ -638,11 +626,11 @@ fn openapi_exports_operations_into_paths() {
     assert!(post["responses"]["204"].get("content").is_none());
 
     // Every `$ref` an operation emits resolves to a component that was exported.
-    let schemas = document.components.as_ref().unwrap();
+    let schemas = value["components"]["schemas"].as_object().unwrap();
     for reference in collect_refs(&value["paths"]) {
         let name = reference.trim_start_matches("#/components/schemas/");
         assert!(
-            schemas.schemas.contains_key(name),
+            schemas.contains_key(name),
             "operation $ref {reference:?} does not resolve"
         );
     }
@@ -682,15 +670,15 @@ fn openapi_resolves_operations_against_disambiguated_component_names() {
         .operation(Operation::get("/b").response::<other::Recipe>(200, "inner"))
         .export_document(&types, specta_serde::Format)
         .expect("colliding names should still resolve");
-    let value = serde_json::to_value(&document).unwrap();
+    let value = document;
 
-    let schemas = document.components.as_ref().unwrap();
+    let schemas = value["components"]["schemas"].as_object().unwrap();
     let refs = collect_refs(&value["paths"]);
     assert_eq!(refs.len(), 2);
     for reference in &refs {
         let name = reference.trim_start_matches("#/components/schemas/");
         assert!(
-            schemas.schemas.contains_key(name),
+            schemas.contains_key(name),
             "disambiguated $ref {reference:?} does not resolve"
         );
     }
@@ -740,7 +728,7 @@ fn openapi_resolves_generic_operation_types() {
         .operation(Operation::get("/recipe").response::<Wrapper<Recipe>>(200, "wrapped recipe"))
         .export_document(&types, specta_serde::Format)
         .expect("generic instantiations should resolve");
-    let value = serde_json::to_value(&document).unwrap();
+    let value = document;
 
     // Each instantiation is its own component, so the two operations must not collapse onto one.
     let text =
@@ -756,11 +744,11 @@ fn openapi_resolves_generic_operation_types() {
         .to_string();
     assert_ne!(text, recipe);
 
-    let schemas = document.components.as_ref().unwrap();
+    let schemas = value["components"]["schemas"].as_object().unwrap();
     for reference in [&text, &recipe] {
         let name = reference.trim_start_matches("#/components/schemas/");
         assert!(
-            schemas.schemas.contains_key(name),
+            schemas.contains_key(name),
             "generic $ref {reference:?} does not resolve"
         );
     }
@@ -779,17 +767,17 @@ fn openapi_resolution_probe_does_not_leak_into_the_document() {
         .export_document(&types, specta_serde::Format)
         .expect("types should export");
 
-    let components = with_operations.components.as_ref().unwrap();
+    let components = &with_operations["components"];
     assert!(
-        components
-            .schemas
+        components["schemas"]
+            .as_object()
+            .unwrap()
             .keys()
             .all(|name| !name.contains("probe")),
         "the probe leaked into the components"
     );
     assert_eq!(
-        serde_json::to_value(&components).unwrap(),
-        serde_json::to_value(without_operations.components.as_ref().unwrap()).unwrap(),
+        components, &without_operations["components"],
         "describing operations changed the exported components"
     );
 }
@@ -812,7 +800,7 @@ fn openapi_inlines_operation_types_that_have_no_component() {
             specta_serde::Format,
         )
         .expect("an inlined type should be written in place");
-    let value = serde_json::to_value(&document).unwrap();
+    let value = document;
 
     let schema = &value["paths"]["/inlined"]["get"]["responses"]["200"]["content"]["application/json"]
         ["schema"];
@@ -836,7 +824,7 @@ fn openapi_types_parameters_from_their_extracted_type() {
         )
         .export_document(&recipe_types(), specta_serde::Format)
         .expect("typed parameters should export");
-    let value = serde_json::to_value(&document).unwrap();
+    let value = document;
     let parameters = &value["paths"]["/users/{id}"]["get"]["parameters"];
 
     assert_eq!(parameters[0]["name"], "id");
@@ -887,8 +875,7 @@ fn numeric_formats_and_compact_string_enums() {
     let document = OpenApi::default()
         .export_document(&types, specta_serde::Format)
         .unwrap();
-    let json = serde_json::to_value(&document).unwrap();
-    let schemas = &json["components"]["schemas"];
+    let schemas = &document["components"]["schemas"];
 
     let numeric = &schemas["NumericFormats"]["properties"];
     assert_eq!(numeric["small"]["format"], "int32");
@@ -931,8 +918,7 @@ fn parameters_carry_required_description_and_example() {
         )
         .export_document(&types, specta_serde::Format)
         .unwrap();
-    let json = serde_json::to_value(&document).unwrap();
-    let parameters = &json["paths"]["/v1/weather/forecast"]["get"]["parameters"];
+    let parameters = &document["paths"]["/v1/weather/forecast"]["get"]["parameters"];
 
     assert_eq!(parameters[0]["name"], "lat");
     assert_eq!(parameters[0]["required"], true);
@@ -943,8 +929,8 @@ fn parameters_carry_required_description_and_example() {
     assert_eq!(parameters[0]["example"], 35.0);
     assert_eq!(parameters[0]["schema"]["format"], "double");
 
-    // The bare convenience stays optional (openapiv3 omits `required: false`)
-    // with no annotations.
+    // The bare convenience stays optional (`required: false` is the spec
+    // default and is omitted) with no annotations.
     assert_eq!(parameters[1]["name"], "horizon_hours");
     assert_ne!(parameters[1]["required"], serde_json::json!(true));
     assert!(parameters[1].get("example").is_none());
@@ -977,7 +963,7 @@ fn content_types_security_and_document_metadata() {
         )
         .export_document(&types, specta_serde::Format)
         .unwrap();
-    let json = serde_json::to_value(&document).unwrap();
+    let json = document;
 
     assert_eq!(json["servers"][0]["url"], "https://api.orr.sh");
     assert_eq!(json["servers"][0]["description"], "Production");

--- a/tests/tests/openapi.rs
+++ b/tests/tests/openapi.rs
@@ -1376,3 +1376,117 @@ fn openapi_emits_string_formats_for_well_known_types() {
         );
     }
 }
+
+/// Operations resolve per phase: request bodies and parameters describe what
+/// the server deserializes, responses what it serializes. Under the unified
+/// format both sides are one component; under `PhasesFormat` a type whose
+/// phases diverge splits, and each side references its own projection.
+#[test]
+fn operations_are_phase_aware_under_phases_format() {
+    #[derive(Type, Serialize, Deserialize)]
+    #[specta(collect = false)]
+    struct Draft {
+        id: u32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        note: Option<String>,
+    }
+
+    let operation = || {
+        Operation::post("/drafts")
+            .request_body::<Draft>()
+            .response::<Draft>(201, "Created")
+    };
+
+    let unified = OpenApi::default()
+        .operation(operation())
+        .export_document(&Types::default().register::<Draft>(), specta_serde::Format)
+        .expect("unified export");
+    let op = &unified["paths"]["/drafts"]["post"];
+    assert_eq!(
+        op["requestBody"]["content"]["application/json"]["schema"]["$ref"],
+        "#/components/schemas/Draft"
+    );
+    assert_eq!(
+        op["responses"]["201"]["content"]["application/json"]["schema"]["$ref"],
+        "#/components/schemas/Draft"
+    );
+
+    let phased = OpenApi::default()
+        .operation(operation())
+        .export_document(
+            &Types::default().register::<Draft>(),
+            specta_serde::PhasesFormat,
+        )
+        .expect("phased export");
+    let op = &phased["paths"]["/drafts"]["post"];
+    assert_eq!(
+        op["requestBody"]["content"]["application/json"]["schema"]["$ref"],
+        "#/components/schemas/Draft_Deserialize"
+    );
+    assert_eq!(
+        op["responses"]["201"]["content"]["application/json"]["schema"]["$ref"],
+        "#/components/schemas/Draft_Serialize"
+    );
+
+    // The projections say different, individually true things about `note`:
+    // serialization omits it when `None` and never writes null; a client may
+    // send it absent, null, or a string.
+    let serialize = &phased["components"]["schemas"]["Draft_Serialize"];
+    let deserialize = &phased["components"]["schemas"]["Draft_Deserialize"];
+    assert_eq!(serialize["required"], serde_json::json!(["id"]));
+    assert_eq!(deserialize["required"], serde_json::json!(["id"]));
+    assert_eq!(serialize["properties"]["note"]["type"], "string");
+    assert!(
+        deserialize["properties"]["note"].get("anyOf").is_some()
+            || deserialize["properties"]["note"]["type"].is_array(),
+        "the deserialize projection should admit null: {}",
+        deserialize["properties"]["note"]
+    );
+}
+
+/// A plain `Option` field - no serde attributes at all - also splits per
+/// phase: serde always writes the key on the way out and accepts its absence
+/// on the way in, so the serialize projection lists it required-and-nullable
+/// while the deserialize projection drops it from `required`. Both statements
+/// are exactly true for their direction; a single-schema generator must pick
+/// one and be half-wrong.
+#[test]
+fn plain_option_fields_split_per_phase() {
+    #[derive(Type, Serialize, Deserialize)]
+    #[specta(collect = false)]
+    struct Plain {
+        plain: Option<String>,
+        id: u32,
+    }
+
+    let phased = OpenApi::default()
+        .operation(
+            Operation::post("/p")
+                .request_body::<Plain>()
+                .response::<Plain>(201, "Created"),
+        )
+        .export_document(
+            &Types::default().register::<Plain>(),
+            specta_serde::PhasesFormat,
+        )
+        .expect("phased export");
+
+    let op = &phased["paths"]["/p"]["post"];
+    assert_eq!(
+        op["requestBody"]["content"]["application/json"]["schema"]["$ref"],
+        "#/components/schemas/Plain_Deserialize"
+    );
+    assert_eq!(
+        op["responses"]["201"]["content"]["application/json"]["schema"]["$ref"],
+        "#/components/schemas/Plain_Serialize"
+    );
+    let schemas = &phased["components"]["schemas"];
+    assert_eq!(
+        schemas["Plain_Serialize"]["required"],
+        serde_json::json!(["plain", "id"])
+    );
+    assert_eq!(
+        schemas["Plain_Deserialize"]["required"],
+        serde_json::json!(["id"])
+    );
+}

--- a/tests/tests/openapi.rs
+++ b/tests/tests/openapi.rs
@@ -1253,3 +1253,37 @@ fn openapi_documents_validate_against_the_official_meta_schemas() {
         );
     }
 }
+
+/// Well-known string-shaped types carry their JSON Schema `format`, keyed by
+/// the same identity `specta_typescript::semantic` matches on; overrides and
+/// plain strings stay bare.
+#[test]
+fn openapi_emits_string_formats_for_well_known_types() {
+    #[derive(Type)]
+    #[specta(collect = false)]
+    struct Meeting {
+        starts_at: chrono::DateTime<chrono::Utc>,
+        day: chrono::NaiveDate,
+        agenda: String,
+        #[specta(type = String)]
+        overridden: chrono::DateTime<chrono::Utc>,
+    }
+
+    for version in [OasVersion::V3_0, OasVersion::V3_1] {
+        let document = OpenApi::default()
+            .oas_version(version)
+            .export_document(
+                &Types::default().register::<Meeting>(),
+                specta_serde::Format,
+            )
+            .expect("chrono fields should export");
+        let properties = &document["components"]["schemas"]["Meeting"]["properties"];
+        assert_eq!(properties["starts_at"]["format"], "date-time");
+        assert_eq!(properties["day"]["format"], "date");
+        assert!(properties["agenda"].get("format").is_none());
+        assert!(
+            properties["overridden"].get("format").is_none(),
+            "a type override must win over the format table"
+        );
+    }
+}

--- a/tests/tests/openapi.rs
+++ b/tests/tests/openapi.rs
@@ -1118,6 +1118,7 @@ fn content_types_security_and_document_metadata() {
         .version("1.0.0")
         .server_described("https://api.orr.sh", "Production")
         .contact("Orrery", "https://orreryhq.com")
+        .license_spdx("Apache-2.0", "Apache-2.0")
         .tag("weather", "Weather intelligence")
         .bearer_security_scheme("api_key", "opaque")
         .operation(
@@ -1139,6 +1140,7 @@ fn content_types_security_and_document_metadata() {
     assert_eq!(json["servers"][0]["url"], "https://api.orr.sh");
     assert_eq!(json["servers"][0]["description"], "Production");
     assert_eq!(json["info"]["contact"]["name"], "Orrery");
+    assert_eq!(json["info"]["license"]["identifier"], "Apache-2.0");
     assert_eq!(json["tags"][0]["description"], "Weather intelligence");
     assert_eq!(
         json["components"]["securitySchemes"]["api_key"]["scheme"],

--- a/tests/tests/openapi.rs
+++ b/tests/tests/openapi.rs
@@ -1054,6 +1054,59 @@ fn parameters_carry_required_description_and_example() {
     assert!(parameters[1].get("example").is_none());
 }
 
+/// A request-body example is a real value of the body type, so the compiler
+/// keeps it true to the schema and serde keeps it true to the wire: the
+/// emitted example carries the type's serde renames, not the Rust field names.
+#[test]
+fn request_body_examples_are_typed_values() {
+    #[derive(Type, Serialize)]
+    #[specta(collect = false)]
+    #[serde(rename_all = "camelCase")]
+    struct SignupRequest {
+        email_address: String,
+    }
+
+    let document = OpenApi::default()
+        .operation(
+            Operation::post("/v1/accounts")
+                .request_body_with_example(SignupRequest {
+                    email_address: "trader@example.com".into(),
+                })
+                .response::<SignupRequest>(201, "Created"),
+        )
+        .export_document(
+            &Types::default().register::<SignupRequest>(),
+            specta_serde::Format,
+        )
+        .expect("typed body examples should export");
+
+    let media =
+        &document["paths"]["/v1/accounts"]["post"]["requestBody"]["content"]["application/json"];
+    assert_eq!(media["example"]["emailAddress"], "trader@example.com");
+    assert_eq!(
+        media["schema"]["$ref"],
+        "#/components/schemas/SignupRequest"
+    );
+
+    // A body declared without an example carries none.
+    let bare = OpenApi::default()
+        .operation(
+            Operation::post("/v1/accounts")
+                .request_body::<SignupRequest>()
+                .response::<SignupRequest>(201, "Created"),
+        )
+        .export_document(
+            &Types::default().register::<SignupRequest>(),
+            specta_serde::Format,
+        )
+        .expect("bare bodies should export");
+    assert!(
+        bare["paths"]["/v1/accounts"]["post"]["requestBody"]["content"]["application/json"]
+            .get("example")
+            .is_none()
+    );
+}
+
 /// Error responses can be served as `application/problem+json`, security
 /// schemes register on the document, and operations state their security
 /// alternatives, the anonymous option included.

--- a/tests/tests/openapi.rs
+++ b/tests/tests/openapi.rs
@@ -1173,7 +1173,73 @@ fn openapi_documents_validate_against_the_official_meta_schemas() {
     let meta_30: serde_json::Value =
         serde_json::from_str(include_str!("../schemas/openapi-3.0-2024-10-18.json"))
             .expect("vendored 3.0 meta-schema parses");
-    let validator_31 = jsonschema::validator_for(&meta_31).expect("3.1 meta-schema compiles");
+    // The base 3.1 meta-schema deliberately skips Schema Object validation;
+    // schema-base pins the OAS dialect so schemas are deep-validated too. Its
+    // reference chain (the base meta and the dialect meta) is vendored beside
+    // it and registered under the canonical URIs.
+    let mut meta_31_schema_base: serde_json::Value = serde_json::from_str(include_str!(
+        "../schemas/openapi-3.1-schema-base-2025-11-23.json"
+    ))
+    .expect("vendored 3.1 schema-base meta parses");
+    // The validator loses schema-base's lexical base URI when resolving its
+    // two same-document pointers from inside the dynamic scope. Both point at
+    // `$defs/dialect`, a one-line const, so inline it: identical semantics,
+    // vendored bytes untouched.
+    let dialect_const = meta_31_schema_base["$defs"]["dialect"].clone();
+    fn inline_dialect_pointer(value: &mut serde_json::Value, replacement: &serde_json::Value) {
+        match value {
+            serde_json::Value::Object(object) => {
+                if object.get("$ref").and_then(serde_json::Value::as_str) == Some("#/$defs/dialect")
+                {
+                    *value = replacement.clone();
+                    return;
+                }
+                for child in object.values_mut() {
+                    inline_dialect_pointer(child, replacement);
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for item in items {
+                    inline_dialect_pointer(item, replacement);
+                }
+            }
+            _ => {}
+        }
+    }
+    inline_dialect_pointer(&mut meta_31_schema_base, &dialect_const);
+    let meta_31_dialect: serde_json::Value = serde_json::from_str(include_str!(
+        "../schemas/openapi-3.1-dialect-2024-11-10.json"
+    ))
+    .expect("vendored 3.1 dialect meta parses");
+    let meta_31_vocabulary: serde_json::Value =
+        serde_json::from_str(include_str!("../schemas/openapi-3.1-meta-2024-11-10.json"))
+            .expect("vendored 3.1 vocabulary meta parses");
+    struct VendoredMetas {
+        base: serde_json::Value,
+        dialect: serde_json::Value,
+        vocabulary: serde_json::Value,
+    }
+    impl jsonschema::Retrieve for VendoredMetas {
+        fn retrieve(
+            &self,
+            uri: &jsonschema::Uri<String>,
+        ) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
+            match uri.as_str() {
+                "https://spec.openapis.org/oas/3.1/schema/2025-11-23" => Ok(self.base.clone()),
+                "https://spec.openapis.org/oas/3.1/dialect/2024-11-10" => Ok(self.dialect.clone()),
+                "https://spec.openapis.org/oas/3.1/meta/2024-11-10" => Ok(self.vocabulary.clone()),
+                other => Err(format!("no vendored meta-schema for {other}").into()),
+            }
+        }
+    }
+    let validator_31 = jsonschema::options()
+        .with_retriever(VendoredMetas {
+            base: meta_31.clone(),
+            dialect: meta_31_dialect,
+            vocabulary: meta_31_vocabulary,
+        })
+        .build(&meta_31_schema_base)
+        .expect("3.1 schema-base meta compiles");
     let validator_30 = jsonschema::validator_for(&meta_30).expect("3.0 meta-schema compiles");
 
     let full_surface = |version: OasVersion| {
@@ -1226,6 +1292,21 @@ fn openapi_documents_validate_against_the_official_meta_schemas() {
         .export_document(&types, specta_serde::Format)
         .expect("3.0 corpus exports");
 
+    // Prove the deep net bites where the base meta is blind by design: a
+    // corrupt Schema Object passes the base 3.1 meta (which skips Schema
+    // Object validation) and must fail schema-base.
+    let base_only = jsonschema::validator_for(&meta_31).expect("3.1 base meta compiles");
+    let mut corrupted = full_surface(OasVersion::V3_1);
+    corrupted["components"]["schemas"]["Recipe"]["type"] = serde_json::json!(123);
+    assert!(
+        base_only.iter_errors(&corrupted).next().is_none(),
+        "the base meta skips Schema Objects by design; if this fires, drop the schema-base layer"
+    );
+    assert!(
+        validator_31.iter_errors(&corrupted).next().is_some(),
+        "schema-base must reject a corrupt Schema Object"
+    );
+
     let cases = [
         (
             "3.1 full-surface",
@@ -1264,6 +1345,10 @@ fn openapi_emits_string_formats_for_well_known_types() {
     struct Meeting {
         starts_at: chrono::DateTime<chrono::Utc>,
         day: chrono::NaiveDate,
+        stamped: jiff::Timestamp,
+        civil_day: jiff::civil::Date,
+        id: uuid::Uuid,
+        link: url::Url,
         agenda: String,
         #[specta(type = String)]
         overridden: chrono::DateTime<chrono::Utc>,
@@ -1280,6 +1365,10 @@ fn openapi_emits_string_formats_for_well_known_types() {
         let properties = &document["components"]["schemas"]["Meeting"]["properties"];
         assert_eq!(properties["starts_at"]["format"], "date-time");
         assert_eq!(properties["day"]["format"], "date");
+        assert_eq!(properties["stamped"]["format"], "date-time");
+        assert_eq!(properties["civil_day"]["format"], "date");
+        assert_eq!(properties["id"]["format"], "uuid");
+        assert_eq!(properties["link"]["format"], "uri");
         assert!(properties["agenda"].get("format").is_none());
         assert!(
             properties["overridden"].get("format").is_none(),

--- a/tests/tests/openapi.rs
+++ b/tests/tests/openapi.rs
@@ -5,7 +5,7 @@ use specta::{
     Type, Types,
     datatype::{DataType, Field, NamedDataType, Primitive, Struct},
 };
-use specta_openapi::{OpenApi, Operation, OutputFormat, SchemaMode};
+use specta_openapi::{OasVersion, OpenApi, Operation, OutputFormat, SchemaMode};
 
 #[derive(Type, Serialize, Deserialize)]
 #[specta(collect = false)]
@@ -146,16 +146,17 @@ enum OverlappingUntagged {
 #[test]
 fn openapi_exports_full_type_corpus() {
     let (types, _) = crate::types();
+
+    // OpenAPI 3.1's dialect is full JSON Schema, so the whole corpus exports
+    // under the default strict mode with nothing approximated.
     let output = OpenApi::default()
         .title("Specta corpus")
         .version("1.0.0")
-        .schema_mode(SchemaMode::Compatible)
         .export(&types, specta_serde::Format)
-        .expect("the shared type corpus should be representable in OpenAPI");
-
+        .expect("the shared type corpus should be representable in OpenAPI 3.1");
     let document: serde_json::Value =
         serde_json::from_str(&output).expect("output should be a valid OpenAPI document");
-    assert_eq!(document["openapi"], "3.0.3");
+    assert_eq!(document["openapi"], "3.1.0");
     assert!(
         document["components"]["schemas"]
             .as_object()
@@ -163,6 +164,19 @@ fn openapi_exports_full_type_corpus() {
             .len()
             > 20
     );
+
+    // OpenAPI 3.0's restricted dialect still carries the corpus in
+    // compatible mode.
+    let output = OpenApi::default()
+        .title("Specta corpus")
+        .version("1.0.0")
+        .oas_version(OasVersion::V3_0)
+        .schema_mode(SchemaMode::Compatible)
+        .export(&types, specta_serde::Format)
+        .expect("the shared type corpus should be representable in OpenAPI 3.0");
+    let document: serde_json::Value =
+        serde_json::from_str(&output).expect("output should be a valid OpenAPI document");
+    assert_eq!(document["openapi"], "3.0.3");
 }
 
 #[test]
@@ -193,6 +207,7 @@ fn openapi_preserves_shapes_metadata_and_generics() {
         .register::<ReferencedField>()
         .register::<OverlappingUntagged>();
     let document = OpenApi::default()
+        .oas_version(OasVersion::V3_0)
         .schema_mode(SchemaMode::Compatible)
         .export_document(&types, specta_serde::Format)
         .expect("representative shapes should export");
@@ -249,6 +264,24 @@ fn openapi_preserves_shapes_metadata_and_generics() {
         "openapi-representative-shapes",
         serde_json::to_string_pretty(&value).expect("snapshot value should serialize")
     );
+
+    // The same shapes under the default 3.1 dialect, where JSON Schema
+    // keywords survive verbatim and strict mode has nothing to reject.
+    let document = OpenApi::default()
+        .export_document(&types, specta_serde::Format)
+        .expect("representative shapes should export as OpenAPI 3.1");
+    assert_eq!(document["openapi"], "3.1.0");
+    let schemas = &document["components"]["schemas"];
+    assert!(
+        schemas["ApiModel_String"]["properties"]["optionalValue"]
+            .get("nullable")
+            .is_none(),
+        "3.1 has no `nullable` keyword"
+    );
+    insta::assert_snapshot!(
+        "openapi-representative-shapes-3-1",
+        serde_json::to_string_pretty(&document).expect("snapshot value should serialize")
+    );
 }
 
 #[test]
@@ -271,6 +304,7 @@ fn openapi_materializes_directly_registered_generic_root() {
 #[test]
 fn openapi_strict_mode_rejects_lossy_openapi_3_shapes() {
     let optional = OpenApi::default()
+        .oas_version(OasVersion::V3_0)
         .export_document(
             &Types::default().register::<StrictOptionalPrimitive>(),
             specta_serde::Format,
@@ -294,6 +328,7 @@ fn openapi_strict_mode_rejects_lossy_openapi_3_shapes() {
     );
 
     let homogeneous = OpenApi::default()
+        .oas_version(OasVersion::V3_0)
         .export_document(
             &Types::default().register::<StrictHomogeneousTuple>(),
             specta_serde::Format,
@@ -305,12 +340,14 @@ fn openapi_strict_mode_rejects_lossy_openapi_3_shapes() {
     assert_eq!(homogeneous["maxItems"], 2);
 
     OpenApi::default()
+        .oas_version(OasVersion::V3_0)
         .export(
             &Types::default().register::<StringMap>(),
             specta_serde::Format,
         )
         .expect("ordinary string-key maps are exactly representable");
     OpenApi::default()
+        .oas_version(OasVersion::V3_0)
         .export(
             &Types::default().register::<NamedStringMap>(),
             specta_serde::Format,
@@ -318,6 +355,7 @@ fn openapi_strict_mode_rejects_lossy_openapi_3_shapes() {
         .expect("transparent string-newtype map keys are exactly representable");
 
     let error = OpenApi::default()
+        .oas_version(OasVersion::V3_0)
         .schema_mode(SchemaMode::Strict)
         .export(
             &Types::default().register::<StrictTuple>(),
@@ -331,6 +369,7 @@ fn openapi_strict_mode_rejects_lossy_openapi_3_shapes() {
     );
 
     let compatible = OpenApi::default()
+        .oas_version(OasVersion::V3_0)
         .schema_mode(SchemaMode::Compatible)
         .export_document(
             &Types::default().register::<StrictTuple>(),
@@ -345,6 +384,7 @@ fn openapi_strict_mode_rejects_lossy_openapi_3_shapes() {
     );
 
     let map_error = OpenApi::default()
+        .oas_version(OasVersion::V3_0)
         .schema_mode(SchemaMode::Strict)
         .export(
             &Types::default().register::<StrictMap>(),
@@ -354,6 +394,7 @@ fn openapi_strict_mode_rejects_lossy_openapi_3_shapes() {
     assert!(map_error.to_string().contains("constrained map keys"));
 
     let enum_map = OpenApi::default()
+        .oas_version(OasVersion::V3_0)
         .schema_mode(SchemaMode::Compatible)
         .export_document(
             &Types::default().register::<EnumMap>(),
@@ -366,6 +407,7 @@ fn openapi_strict_mode_rejects_lossy_openapi_3_shapes() {
     );
 
     let null_error = OpenApi::default()
+        .oas_version(OasVersion::V3_0)
         .export(
             &Types::default().register::<StrictUnit>(),
             specta_serde::Format,
@@ -374,6 +416,7 @@ fn openapi_strict_mode_rejects_lossy_openapi_3_shapes() {
     assert!(null_error.to_string().contains("null-only types"));
 
     let compatible_unit = OpenApi::default()
+        .oas_version(OasVersion::V3_0)
         .schema_mode(SchemaMode::Compatible)
         .export_document(
             &Types::default().register::<StrictUnit>(),
@@ -388,6 +431,7 @@ fn openapi_strict_mode_rejects_lossy_openapi_3_shapes() {
     assert_eq!(compatible_unit["x-specta-type"], "null");
 
     let flattened = OpenApi::default()
+        .oas_version(OasVersion::V3_0)
         .export_document(
             &Types::default().register::<StrictFlattened>(),
             specta_serde::Format,
@@ -401,6 +445,7 @@ fn openapi_strict_mode_rejects_lossy_openapi_3_shapes() {
     // `Option<T>` over a named type is the most common shape strict mode rejects: OpenAPI 3.0
     // cannot mark a `$ref` nullable.
     let reference_error = OpenApi::default()
+        .oas_version(OasVersion::V3_0)
         .export_document(
             &Types::default().register::<StrictOptionalReference>(),
             specta_serde::Format,
@@ -412,6 +457,7 @@ fn openapi_strict_mode_rejects_lossy_openapi_3_shapes() {
             .contains("nullable references or composed schemas")
     );
     let compatible_reference = OpenApi::default()
+        .oas_version(OasVersion::V3_0)
         .schema_mode(SchemaMode::Compatible)
         .export_document(
             &Types::default().register::<StrictOptionalReference>(),
@@ -425,13 +471,85 @@ fn openapi_strict_mode_rejects_lossy_openapi_3_shapes() {
             .is_some()
     );
 
-    // Strict is the default, so every rejection names the way out.
+    // Strict is the default, so every rejection names both ways out: the
+    // compatible approximation and the dialect that expresses the shape.
     for error in [&error, &map_error, &null_error, &reference_error] {
         assert!(
             error.to_string().contains("SchemaMode::Compatible"),
             "strict-mode error should point at the escape hatch: {error}"
         );
+        assert!(
+            error.to_string().contains("OasVersion::V3_1"),
+            "strict-mode error should point at the 3.1 dialect: {error}"
+        );
     }
+}
+
+/// Under the default OpenAPI 3.1 dialect the JSON Schema keywords survive
+/// verbatim, so every shape strict mode rejects for 3.0 exports untouched.
+#[test]
+fn openapi_3_1_preserves_json_schema_shapes() {
+    let unit = OpenApi::default()
+        .export_document(
+            &Types::default().register::<StrictUnit>(),
+            specta_serde::Format,
+        )
+        .expect("a null-only type is a legal 3.1 schema");
+    let unit = &unit["components"]["schemas"]["StrictUnit"];
+    assert_eq!(unit["type"], "null");
+    assert!(unit.get("nullable").is_none());
+    assert!(unit.get("x-specta-type").is_none());
+
+    let reference = OpenApi::default()
+        .export_document(
+            &Types::default().register::<StrictOptionalReference>(),
+            specta_serde::Format,
+        )
+        .expect("a nullable reference is a legal 3.1 schema");
+    let value =
+        &reference["components"]["schemas"]["StrictOptionalReference"]["properties"]["value"];
+    let members = value["anyOf"]
+        .as_array()
+        .expect("Option<Named> should stay a union");
+    assert!(
+        members
+            .iter()
+            .any(|member| member["type"] == "null" || member.get("type").is_none()),
+        "the null branch should survive: {value}"
+    );
+    assert!(value.get("nullable").is_none());
+    assert!(value.get("x-specta-nullable").is_none());
+
+    let tuple = OpenApi::default()
+        .export_document(
+            &Types::default().register::<StrictTuple>(),
+            specta_serde::Format,
+        )
+        .expect("a heterogeneous tuple is a legal 3.1 schema");
+    let tuple = &tuple["components"]["schemas"]["StrictTuple"];
+    assert_eq!(tuple["prefixItems"].as_array().map(Vec::len), Some(2));
+    assert!(tuple.get("x-specta-prefix-items").is_none());
+
+    let map = OpenApi::default()
+        .export_document(
+            &Types::default().register::<StrictMap>(),
+            specta_serde::Format,
+        )
+        .expect("constrained map keys are a legal 3.1 schema");
+    let map = &map["components"]["schemas"]["StrictMap"];
+    assert!(map.get("propertyNames").is_some());
+    assert!(map.get("x-specta-property-names").is_none());
+
+    let enum_map = OpenApi::default()
+        .export_document(
+            &Types::default().register::<EnumMap>(),
+            specta_serde::Format,
+        )
+        .expect("enum-keyed maps are a legal 3.1 schema");
+    assert_eq!(
+        enum_map["components"]["schemas"]["EnumMap"]["propertyNames"]["$ref"],
+        "#/components/schemas/EnumKey"
+    );
 }
 
 /// Schema bounds are plain JSON numbers, so 64-bit integer bounds are stated
@@ -508,7 +626,7 @@ fn openapi_supports_yaml_export_to_and_document_merging() {
         .expect("YAML export should succeed");
     let parsed: serde_json::Value =
         serde_yaml::from_str(&yaml).expect("YAML should be a valid OpenAPI document");
-    assert_eq!(parsed["openapi"], "3.0.3");
+    assert_eq!(parsed["openapi"], "3.1.0");
 
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("target")

--- a/tests/tests/openapi.rs
+++ b/tests/tests/openapi.rs
@@ -552,24 +552,29 @@ fn openapi_3_1_preserves_json_schema_shapes() {
     );
 }
 
-/// Schema bounds are plain JSON numbers, so 64-bit integer bounds are stated
-/// exactly in either schema mode — the spec has no integer-width limit.
+/// Signed 64-bit bounds are stated exactly; bounds beyond that range are
+/// carried in extensions in every dialect and mode, because mainstream
+/// generators parse bounds into signed 64-bit integers and silently wrap
+/// anything wider.
 #[test]
-fn openapi_emits_exact_wide_integer_bounds() {
+fn openapi_carries_wide_integer_bounds_in_extensions() {
     let types = Types::default().register::<WideIntegers>();
-    for mode in [SchemaMode::Strict, SchemaMode::Compatible] {
-        let document = OpenApi::default()
-            .schema_mode(mode)
-            .export_document(&types, specta_serde::Format)
-            .expect("64-bit integer bounds are exactly representable");
-        let properties = &document["components"]["schemas"]["WideIntegers"]["properties"];
+    for version in [OasVersion::V3_0, OasVersion::V3_1] {
+        for mode in [SchemaMode::Strict, SchemaMode::Compatible] {
+            let document = OpenApi::default()
+                .oas_version(version)
+                .schema_mode(mode)
+                .export_document(&types, specta_serde::Format)
+                .expect("wide integer bounds should always export");
+            let properties = &document["components"]["schemas"]["WideIntegers"]["properties"];
 
-        assert_eq!(properties["signed"]["maximum"], i64::MAX);
-        assert_eq!(properties["signed"]["minimum"], i64::MIN);
-        assert!(properties["signed"].get("x-specta-maximum").is_none());
-        assert_eq!(properties["unsigned"]["maximum"], u64::MAX);
-        assert!(properties["unsigned"].get("x-specta-maximum").is_none());
-        assert_eq!(properties["unsigned"]["minimum"], 0.0);
+            assert_eq!(properties["signed"]["maximum"], i64::MAX);
+            assert_eq!(properties["signed"]["minimum"], i64::MIN);
+            assert!(properties["signed"].get("x-specta-maximum").is_none());
+            assert!(properties["unsigned"].get("maximum").is_none());
+            assert_eq!(properties["unsigned"]["x-specta-maximum"], u64::MAX);
+            assert_eq!(properties["unsigned"]["minimum"], 0.0);
+        }
     }
 }
 
@@ -1154,4 +1159,97 @@ fn content_types_security_and_document_metadata() {
         operation["security"],
         serde_json::json!([{ "api_key": [] }, {}])
     );
+}
+
+/// Every emitted document validates against the official OAS meta-schema for
+/// its declared version, vendored from spec.openapis.org (the 3.0 line's
+/// 2024-10-18 iteration and the 3.1 line's 2025-11-23 iteration; per the
+/// spec, the latest iteration within a minor line covers all its patches).
+#[test]
+fn openapi_documents_validate_against_the_official_meta_schemas() {
+    let meta_31: serde_json::Value =
+        serde_json::from_str(include_str!("../schemas/openapi-3.1-2025-11-23.json"))
+            .expect("vendored 3.1 meta-schema parses");
+    let meta_30: serde_json::Value =
+        serde_json::from_str(include_str!("../schemas/openapi-3.0-2024-10-18.json"))
+            .expect("vendored 3.0 meta-schema parses");
+    let validator_31 = jsonschema::validator_for(&meta_31).expect("3.1 meta-schema compiles");
+    let validator_30 = jsonschema::validator_for(&meta_30).expect("3.0 meta-schema compiles");
+
+    let full_surface = |version: OasVersion| {
+        OpenApi::default()
+            .oas_version(version)
+            .title("Meta-schema conformance")
+            .version("1.0.0")
+            .description("Exercises the exporter's whole document surface.")
+            .contact("Specta", "https://specta.dev")
+            .license_spdx("MIT", "MIT")
+            .server_described("https://api.example.com", "Production")
+            .tag("recipes", "Recipe endpoints")
+            .bearer_security_scheme("api_key", "sk_...")
+            .operation(
+                Operation::get("/recipes/{slug}")
+                    .operation_id("getRecipe")
+                    .tag("recipes")
+                    .summary("Fetch one recipe")
+                    .path_param::<String>("slug")
+                    .parameter(
+                        specta_openapi::Param::query::<u32>("limit")
+                            .description("Max results")
+                            .example(serde_json::json!(10)),
+                    )
+                    .header_param::<String>("x-request-id")
+                    .response::<Recipe>(200, "The recipe")
+                    .response_as::<ApiError>(404, "No such recipe", "application/problem+json")
+                    .security([("api_key", Vec::new())])
+                    .security_optional(),
+            )
+            .operation(
+                Operation::post("/recipes")
+                    .operation_id("createRecipe")
+                    .tag("recipes")
+                    .request_body::<NewRecipe>()
+                    .response::<Recipe>(201, "Created")
+                    .empty_response(204, "Nothing to do"),
+            )
+            .export_document(&recipe_types(), specta_serde::Format)
+            .expect("full-surface document exports")
+    };
+
+    let (types, _) = crate::types();
+    let corpus_31 = OpenApi::default()
+        .export_document(&types, specta_serde::Format)
+        .expect("3.1 corpus exports");
+    let corpus_30 = OpenApi::default()
+        .oas_version(OasVersion::V3_0)
+        .schema_mode(SchemaMode::Compatible)
+        .export_document(&types, specta_serde::Format)
+        .expect("3.0 corpus exports");
+
+    let cases = [
+        (
+            "3.1 full-surface",
+            full_surface(OasVersion::V3_1),
+            &validator_31,
+        ),
+        (
+            "3.0 full-surface",
+            full_surface(OasVersion::V3_0),
+            &validator_30,
+        ),
+        ("3.1 corpus", corpus_31, &validator_31),
+        ("3.0 corpus", corpus_30, &validator_30),
+    ];
+    for (label, document, validator) in cases {
+        let errors: Vec<String> = validator
+            .iter_errors(&document)
+            .map(|error| format!("  {} at {}", error, error.instance_path()))
+            .take(8)
+            .collect();
+        assert!(
+            errors.is_empty(),
+            "{label} document violates its meta-schema:\n{}",
+            errors.join("\n")
+        );
+    }
 }

--- a/tests/tests/snapshots/test__jsonschema__jsonschema-export-serde.snap
+++ b/tests/tests/snapshots/test__jsonschema__jsonschema-export-serde.snap
@@ -4675,7 +4675,6 @@ expression: "JsonSchema::default().export(&types, specta_serde::Format).unwrap()
         "&'static [i32]",
         "&'static [i32; 3]",
         "[i32; 3]",
-        "Vec<MyEnum>",
         "&'static [MyEnum]",
         "&'static [MyEnum; 6]",
         "[MyEnum; 2]",
@@ -4889,7 +4888,6 @@ expression: "JsonSchema::default().export(&types, specta_serde::Format).unwrap()
         "NamedConstGenericContainer",
         "InlineConstGenericContainer",
         "InlineRecursiveConstGenericContainer",
-        "TestCollectionRegister",
         "TestCollectionRegister"
       ],
       "title": "Primitives",

--- a/tests/tests/snapshots/test__jsonschema__jsonschema-export-serde_phases.snap
+++ b/tests/tests/snapshots/test__jsonschema__jsonschema-export-serde_phases.snap
@@ -5709,7 +5709,6 @@ expression: "JsonSchema::default().export(&phased, specta_serde::PhasesFormat).u
         "&'static [i32]",
         "&'static [i32; 3]",
         "[i32; 3]",
-        "Vec<MyEnum>",
         "&'static [MyEnum]",
         "&'static [MyEnum; 6]",
         "[MyEnum; 2]",
@@ -5923,7 +5922,6 @@ expression: "JsonSchema::default().export(&phased, specta_serde::PhasesFormat).u
         "NamedConstGenericContainer",
         "InlineConstGenericContainer",
         "InlineRecursiveConstGenericContainer",
-        "TestCollectionRegister",
         "TestCollectionRegister"
       ],
       "title": "Primitives_Deserialize",
@@ -7203,7 +7201,6 @@ expression: "JsonSchema::default().export(&phased, specta_serde::PhasesFormat).u
         "&'static [i32]",
         "&'static [i32; 3]",
         "[i32; 3]",
-        "Vec<MyEnum>",
         "&'static [MyEnum]",
         "&'static [MyEnum; 6]",
         "[MyEnum; 2]",
@@ -7417,7 +7414,6 @@ expression: "JsonSchema::default().export(&phased, specta_serde::PhasesFormat).u
         "NamedConstGenericContainer",
         "InlineConstGenericContainer",
         "InlineRecursiveConstGenericContainer",
-        "TestCollectionRegister",
         "TestCollectionRegister"
       ],
       "title": "Primitives_Serialize",

--- a/tests/tests/snapshots/test__openapi__openapi-representative-shapes-3-1.snap
+++ b/tests/tests/snapshots/test__openapi__openapi-representative-shapes-3-1.snap
@@ -1,0 +1,277 @@
+---
+source: tests/tests/openapi.rs
+expression: "serde_json::to_string_pretty(&document).expect(\"snapshot value should serialize\")"
+---
+{
+  "components": {
+    "schemas": {
+      "ApiEvent": {
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "kind": {
+                "const": "Started"
+              }
+            },
+            "required": [
+              "kind"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "data": {
+                "additionalProperties": false,
+                "properties": {
+                  "percent": {
+                    "format": "float",
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "percent"
+                ],
+                "type": "object"
+              },
+              "kind": {
+                "const": "Progress"
+              }
+            },
+            "required": [
+              "kind",
+              "data"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "data": {
+                "type": "string"
+              },
+              "kind": {
+                "const": "Message"
+              }
+            },
+            "required": [
+              "kind",
+              "data"
+            ],
+            "type": "object"
+          }
+        ],
+        "title": "ApiEvent"
+      },
+      "ApiModel_String": {
+        "additionalProperties": false,
+        "properties": {
+          "fixed": {
+            "items": {
+              "format": "int32",
+              "maximum": 255,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "maxItems": 2,
+            "minItems": 2,
+            "type": "array"
+          },
+          "id": {
+            "description": " Stable identifier.",
+            "format": "int64",
+            "maximum": 18446744073709551615,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "labels": {
+            "additionalProperties": {
+              "format": "int32",
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer"
+            },
+            "type": "object"
+          },
+          "optionalValue": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tuple": {
+            "items": false,
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              }
+            ],
+            "type": "array"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "value",
+          "optionalValue",
+          "fixed",
+          "tuple",
+          "labels"
+        ],
+        "title": "ApiModel",
+        "type": "object"
+      },
+      "ApiModel_u32": {
+        "additionalProperties": false,
+        "properties": {
+          "fixed": {
+            "items": {
+              "format": "int32",
+              "maximum": 255,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "maxItems": 2,
+            "minItems": 2,
+            "type": "array"
+          },
+          "id": {
+            "description": " Stable identifier.",
+            "format": "int64",
+            "maximum": 18446744073709551615,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "labels": {
+            "additionalProperties": {
+              "format": "int32",
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "type": "integer"
+            },
+            "type": "object"
+          },
+          "optionalValue": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tuple": {
+            "items": false,
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              }
+            ],
+            "type": "array"
+          },
+          "value": {
+            "format": "int64",
+            "maximum": 4294967295,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "value",
+          "optionalValue",
+          "fixed",
+          "tuple",
+          "labels"
+        ],
+        "title": "ApiModel",
+        "type": "object"
+      },
+      "EventAlias": {
+        "$ref": "#/components/schemas/ApiEvent",
+        "title": "EventAlias"
+      },
+      "OverlappingUntagged": {
+        "anyOf": [
+          {
+            "format": "int64",
+            "maximum": 4294967295,
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "format": "int64",
+            "maximum": 4294967295,
+            "minimum": 0,
+            "type": "integer"
+          }
+        ],
+        "title": "OverlappingUntagged"
+      },
+      "ReferencedField": {
+        "additionalProperties": false,
+        "properties": {
+          "event": {
+            "$ref": "#/components/schemas/ApiEvent",
+            "deprecated": true,
+            "description": " Event payload documentation."
+          }
+        },
+        "required": [
+          "event"
+        ],
+        "title": "ReferencedField",
+        "type": "object"
+      },
+      "StringNewtype": {
+        "title": "StringNewtype",
+        "type": "string"
+      },
+      "UsesGenerics": {
+        "additionalProperties": false,
+        "properties": {
+          "event": {
+            "$ref": "#/components/schemas/ApiEvent"
+          },
+          "number": {
+            "$ref": "#/components/schemas/ApiModel_u32"
+          },
+          "text": {
+            "$ref": "#/components/schemas/ApiModel_String"
+          }
+        },
+        "required": [
+          "text",
+          "number",
+          "event"
+        ],
+        "title": "UsesGenerics",
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "Specta API",
+    "version": "0.0.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {}
+}

--- a/tests/tests/snapshots/test__openapi__openapi-representative-shapes-3-1.snap
+++ b/tests/tests/snapshots/test__openapi__openapi-representative-shapes-3-1.snap
@@ -81,9 +81,9 @@ expression: "serde_json::to_string_pretty(&document).expect(\"snapshot value sho
           "id": {
             "description": " Stable identifier.",
             "format": "int64",
-            "maximum": 18446744073709551615,
             "minimum": 0,
-            "type": "integer"
+            "type": "integer",
+            "x-specta-maximum": 18446744073709551615
           },
           "labels": {
             "additionalProperties": {
@@ -150,9 +150,9 @@ expression: "serde_json::to_string_pretty(&document).expect(\"snapshot value sho
           "id": {
             "description": " Stable identifier.",
             "format": "int64",
-            "maximum": 18446744073709551615,
             "minimum": 0,
-            "type": "integer"
+            "type": "integer",
+            "x-specta-maximum": 18446744073709551615
           },
           "labels": {
             "additionalProperties": {

--- a/tests/tests/snapshots/test__openapi__openapi-representative-shapes.snap
+++ b/tests/tests/snapshots/test__openapi__openapi-representative-shapes.snap
@@ -28,6 +28,7 @@ expression: "serde_json::to_string_pretty(&value).expect(\"snapshot value should
                 "additionalProperties": false,
                 "properties": {
                   "percent": {
+                    "format": "float",
                     "type": "number"
                   }
                 },
@@ -74,6 +75,7 @@ expression: "serde_json::to_string_pretty(&value).expect(\"snapshot value should
         "properties": {
           "fixed": {
             "items": {
+              "format": "int32",
               "maximum": 255,
               "minimum": 0,
               "type": "integer"
@@ -84,12 +86,14 @@ expression: "serde_json::to_string_pretty(&value).expect(\"snapshot value should
           },
           "id": {
             "description": " Stable identifier.",
+            "format": "int64",
             "minimum": 0,
             "type": "integer",
             "x-specta-maximum": 18446744073709551615
           },
           "labels": {
             "additionalProperties": {
+              "format": "int32",
               "maximum": 2147483647,
               "minimum": -2147483648,
               "type": "integer"
@@ -144,6 +148,7 @@ expression: "serde_json::to_string_pretty(&value).expect(\"snapshot value should
         "properties": {
           "fixed": {
             "items": {
+              "format": "int32",
               "maximum": 255,
               "minimum": 0,
               "type": "integer"
@@ -154,12 +159,14 @@ expression: "serde_json::to_string_pretty(&value).expect(\"snapshot value should
           },
           "id": {
             "description": " Stable identifier.",
+            "format": "int64",
             "minimum": 0,
             "type": "integer",
             "x-specta-maximum": 18446744073709551615
           },
           "labels": {
             "additionalProperties": {
+              "format": "int32",
               "maximum": 2147483647,
               "minimum": -2147483648,
               "type": "integer"
@@ -195,6 +202,7 @@ expression: "serde_json::to_string_pretty(&value).expect(\"snapshot value should
             ]
           },
           "value": {
+            "format": "int64",
             "maximum": 4294967295,
             "minimum": 0,
             "type": "integer"
@@ -222,11 +230,13 @@ expression: "serde_json::to_string_pretty(&value).expect(\"snapshot value should
       "OverlappingUntagged": {
         "anyOf": [
           {
+            "format": "int64",
             "maximum": 4294967295,
             "minimum": 0,
             "type": "integer"
           },
           {
+            "format": "int64",
             "maximum": 4294967295,
             "minimum": 0,
             "type": "integer"

--- a/tests/tests/snapshots/test__openapi__openapi-representative-shapes.snap
+++ b/tests/tests/snapshots/test__openapi__openapi-representative-shapes.snap
@@ -87,9 +87,9 @@ expression: "serde_json::to_string_pretty(&value).expect(\"snapshot value should
           "id": {
             "description": " Stable identifier.",
             "format": "int64",
+            "maximum": 18446744073709551615,
             "minimum": 0,
-            "type": "integer",
-            "x-specta-maximum": 18446744073709551615
+            "type": "integer"
           },
           "labels": {
             "additionalProperties": {
@@ -160,9 +160,9 @@ expression: "serde_json::to_string_pretty(&value).expect(\"snapshot value should
           "id": {
             "description": " Stable identifier.",
             "format": "int64",
+            "maximum": 18446744073709551615,
             "minimum": 0,
-            "type": "integer",
-            "x-specta-maximum": 18446744073709551615
+            "type": "integer"
           },
           "labels": {
             "additionalProperties": {

--- a/tests/tests/snapshots/test__openapi__openapi-representative-shapes.snap
+++ b/tests/tests/snapshots/test__openapi__openapi-representative-shapes.snap
@@ -87,9 +87,9 @@ expression: "serde_json::to_string_pretty(&value).expect(\"snapshot value should
           "id": {
             "description": " Stable identifier.",
             "format": "int64",
-            "maximum": 18446744073709551615,
             "minimum": 0,
-            "type": "integer"
+            "type": "integer",
+            "x-specta-maximum": 18446744073709551615
           },
           "labels": {
             "additionalProperties": {
@@ -160,9 +160,9 @@ expression: "serde_json::to_string_pretty(&value).expect(\"snapshot value should
           "id": {
             "description": " Stable identifier.",
             "format": "int64",
-            "maximum": 18446744073709551615,
             "minimum": 0,
-            "type": "integer"
+            "type": "integer",
+            "x-specta-maximum": 18446744073709551615
           },
           "labels": {
             "additionalProperties": {


### PR DESCRIPTION
Stacked on #559 — its commit rides first here, and either merge order resolves cleanly (the overlapping hunks are identical). If #559 lands first I'll rebase this down to its own four commits.

This moves the default output to OpenAPI 3.1: its schema dialect is full JSON Schema, which is what the exporter already speaks, so the default target is the lossless one and 3.0 is the deliberate downconversion. `OasVersion::V3_0` keeps 3.0 one call away; nothing else about how the exporter is driven changes.

**Documents assemble as plain JSON, and the openapiv3 dependency is gone.** That crate models 3.0 alone, which capped the exporter at one dialect and hard-coded its i64 schema bounds into the exporter's behavior. `export_document` returns `serde_json::Value`, and `add_to_document` merges into any OpenAPI document as JSON, whichever tool produced it. Integer bounds got decided by measurement instead of by the model: mainstream generators parse bounds into signed 64-bit integers - openapi-generator renders a `u64::MAX` maximum as `maximum: -1`, under 3.0 and 3.1 alike - so bounds beyond the signed 64-bit range are carried in `x-specta-*` extensions in both dialects; the constraint such a bound states is vacuous, so nothing enforceable is lost and the wide-bound Strict trigger stays gone.

**Under 3.1, SchemaMode has nothing left to reject.** The dialect is full JSON Schema: `const`, `prefixItems`, `propertyNames`, `unevaluatedProperties`, boolean schemas, `type: "null"`, null unions, and `$ref`s with siblings all survive verbatim, and the whole shared test corpus exports under the default Strict mode. The 3.0 lowerings still run under `V3_0`, where SchemaMode governs exactly as before, and strict-mode errors now name the 3.1 dialect as the second way out.

Version strings: the spec tells tooling to ignore patch digits, so each variant emits the string its consumers have seen most, `3.0.3` and `3.1.0`.

Operations resolve their types per serde phase: request bodies and parameters describe what the server deserializes, responses what it serializes. Under `specta_serde::Format` nothing changes; export with `PhasesFormat` and each side references its own projection - a `skip_serializing_if` Option renders as an omittable plain string in the response and admits null on the way in, and a plain `Option` field is required-and-nullable outbound while droppable inbound, each statement exactly true for its direction. The format is the switch; there is no knob.

Well-known string-shaped types now carry their JSON Schema `format` - `chrono::DateTime` and `jiff::Timestamp` as `date-time`, `chrono::NaiveDate` and `jiff::civil::Date` as `date`, `url::Url` as `uri`, `uuid::Uuid` as `uuid` - keyed by the same name and module-path identity the semantic-types system matches on, and only where the wire form satisfies the format (`chrono::NaiveDateTime` has no offset, so it carries none). Off by default in specta-jsonschema, on in specta-openapi, and a `#[specta(type = ...)]` override always wins.

Two smaller additions that fell out of real use: request-body examples declared as real values of the body type (`request_body_with_example`), serialized through the type's own serde path so an example cannot drift from the schema it sits beside; and `license`/`license_spdx` for the document info.

The suite now validates every emitted document - the shared corpus and a full-surface operations document, under both dialects - against the vendored official OAS meta-schemas (the 3.0 line's 2024-10-18 iteration and the 3.1 line's 2025-11-23, the latter at schema-base depth so Schema Objects are validated against the OAS dialect, with a probe pinning that the deep layer actually bites). That net caught two real bugs on its first run: the license `identifier` field is OpenAPI 3.1's and is now omitted under 3.0, and a field registered twice left a duplicate `required` entry, deduped at the source in specta-jsonschema. Beyond the suite, a differential harness against the OpenAPI document [orrery.sh](https://orrery.sh) already ships canonicalizes to zero structural differences across all 14 operations and 33 schemas.