### PR TITLE
Set up crates.io publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish-crates:
+    name: Publish workspace to crates.io
+    runs-on: ubuntu-24.04
+    environment: production
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Verify tag matches crate version
+        shell: bash
+        run: |
+          set -euo pipefail
+          crate_version=$(cargo metadata --no-deps --format-version 1 |
+            jq -r '.packages[] | select(.name == "specta") | .version')
+          test "$GITHUB_REF_NAME" = "v$crate_version"
+
+      - name: Authenticate with crates.io
+        id: crates_io_auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Publish crates
+        run: cargo publish --workspace --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates_io_auth.outputs.token }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2288,6 +2288,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "specta-rescript"
+version = "0.0.1"
+dependencies = [
+ "serde",
+ "specta",
+ "specta-serde",
+ "thiserror",
+]
+
+[[package]]
 name = "specta-rust"
 version = "0.0.1"
 dependencies = [


### PR DESCRIPTION
## Summary

- add a tag-triggered release workflow based on `specta-rs/fsk`
- authenticate to crates.io with GitHub OIDC trusted publishing
- verify release tags match the `specta` crate version
- publish all workspace crates in dependency order with Cargo
- refresh the lockfile so locked publishing includes `specta-rescript`

## Impact

Pushing a `v*` tag will publish the workspace through the protected `production` environment after trusted publishing is configured on crates.io.

## Validation

- `cargo publish --workspace --locked --dry-run`
- workflow YAML parse
- `git diff --check`

The packaging dry run succeeds. It reports the existing yanked `spin v0.10.0` lockfile warning.